### PR TITLE
removing deprecated lifecycles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "add-stream": {
@@ -25,9 +25,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
@@ -54,7 +54,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.0"
       }
     },
     "aproba": {
@@ -69,8 +69,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "array-find-index": {
@@ -91,7 +91,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -124,7 +124,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -159,9 +159,9 @@
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0",
-        "map-obj": "^2.0.0",
-        "quick-lru": "^1.0.0"
+        "camelcase": "4.1.0",
+        "map-obj": "2.0.0",
+        "quick-lru": "1.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -185,8 +185,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -195,9 +195,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       }
     },
     "chardet": {
@@ -218,7 +218,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -234,8 +234,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -260,8 +260,8 @@
       "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "~0.5.0"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1"
       }
     },
     "code-point-at": {
@@ -276,7 +276,7 @@
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -291,8 +291,8 @@
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0",
-        "wcwidth": "^1.0.0"
+        "strip-ansi": "3.0.1",
+        "wcwidth": "1.0.1"
       }
     },
     "command-join": {
@@ -307,8 +307,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
       }
     },
     "concat-map": {
@@ -323,10 +323,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "console-control-strings": {
@@ -341,17 +341,17 @@
       "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^1.6.6",
-        "conventional-changelog-atom": "^0.2.8",
-        "conventional-changelog-codemirror": "^0.3.8",
-        "conventional-changelog-core": "^2.0.11",
-        "conventional-changelog-ember": "^0.3.12",
-        "conventional-changelog-eslint": "^1.0.9",
-        "conventional-changelog-express": "^0.3.6",
-        "conventional-changelog-jquery": "^0.1.0",
-        "conventional-changelog-jscs": "^0.1.0",
-        "conventional-changelog-jshint": "^0.3.8",
-        "conventional-changelog-preset-loader": "^1.1.8"
+        "conventional-changelog-angular": "1.6.6",
+        "conventional-changelog-atom": "0.2.8",
+        "conventional-changelog-codemirror": "0.3.8",
+        "conventional-changelog-core": "2.0.11",
+        "conventional-changelog-ember": "0.3.12",
+        "conventional-changelog-eslint": "1.0.9",
+        "conventional-changelog-express": "0.3.6",
+        "conventional-changelog-jquery": "0.1.0",
+        "conventional-changelog-jscs": "0.1.0",
+        "conventional-changelog-jshint": "0.3.8",
+        "conventional-changelog-preset-loader": "1.1.8"
       }
     },
     "conventional-changelog-angular": {
@@ -360,8 +360,8 @@
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-atom": {
@@ -370,7 +370,7 @@
       "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-cli": {
@@ -379,11 +379,11 @@
       "integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
       "dev": true,
       "requires": {
-        "add-stream": "^1.0.0",
-        "conventional-changelog": "^1.1.24",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "tempfile": "^1.1.1"
+        "add-stream": "1.0.0",
+        "conventional-changelog": "1.1.24",
+        "lodash": "4.17.10",
+        "meow": "4.0.1",
+        "tempfile": "1.1.1"
       }
     },
     "conventional-changelog-codemirror": {
@@ -392,7 +392,7 @@
       "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-core": {
@@ -401,19 +401,19 @@
       "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^3.0.9",
-        "conventional-commits-parser": "^2.1.7",
-        "dateformat": "^3.0.0",
-        "get-pkg-repo": "^1.0.0",
-        "git-raw-commits": "^1.3.6",
-        "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^1.3.6",
-        "lodash": "^4.2.1",
-        "normalize-package-data": "^2.3.5",
-        "q": "^1.5.1",
-        "read-pkg": "^1.1.0",
-        "read-pkg-up": "^1.0.1",
-        "through2": "^2.0.0"
+        "conventional-changelog-writer": "3.0.9",
+        "conventional-commits-parser": "2.1.7",
+        "dateformat": "3.0.3",
+        "get-pkg-repo": "1.4.0",
+        "git-raw-commits": "1.3.6",
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "1.3.6",
+        "lodash": "4.17.10",
+        "normalize-package-data": "2.4.0",
+        "q": "1.5.1",
+        "read-pkg": "1.1.0",
+        "read-pkg-up": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "load-json-file": {
@@ -422,11 +422,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "parse-json": {
@@ -435,7 +435,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-type": {
@@ -444,9 +444,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -461,9 +461,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "strip-bom": {
@@ -472,7 +472,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -483,7 +483,7 @@
       "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-eslint": {
@@ -492,7 +492,7 @@
       "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-express": {
@@ -501,7 +501,7 @@
       "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -510,7 +510,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -519,7 +519,7 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jshint": {
@@ -528,8 +528,8 @@
       "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-preset-loader": {
@@ -544,16 +544,16 @@
       "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^1.1.6",
-        "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "semver": "^5.5.0",
-        "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "1.1.6",
+        "dateformat": "3.0.3",
+        "handlebars": "4.0.11",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.10",
+        "meow": "4.0.1",
+        "semver": "5.5.0",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "conventional-commits-filter": {
@@ -562,8 +562,8 @@
       "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
-        "modify-values": "^1.0.0"
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.1"
       }
     },
     "conventional-commits-parser": {
@@ -572,13 +572,13 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
-        "is-text-path": "^1.0.0",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
+        "lodash": "4.17.10",
+        "meow": "4.0.1",
+        "split2": "2.2.0",
+        "through2": "2.0.3",
+        "trim-off-newlines": "1.0.1"
       }
     },
     "conventional-recommended-bump": {
@@ -587,13 +587,13 @@
       "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.10",
-        "conventional-commits-filter": "^1.1.1",
-        "conventional-commits-parser": "^2.1.1",
-        "git-raw-commits": "^1.3.0",
-        "git-semver-tags": "^1.3.0",
-        "meow": "^3.3.0",
-        "object-assign": "^4.0.1"
+        "concat-stream": "1.6.2",
+        "conventional-commits-filter": "1.1.6",
+        "conventional-commits-parser": "2.1.7",
+        "git-raw-commits": "1.3.6",
+        "git-semver-tags": "1.3.6",
+        "meow": "3.7.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "camelcase": {
@@ -608,8 +608,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "indent-string": {
@@ -618,7 +618,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "map-obj": {
@@ -633,16 +633,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "minimist": {
@@ -657,8 +657,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "strip-indent": {
@@ -667,7 +667,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -690,7 +690,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "cross-spawn": {
@@ -699,9 +699,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "currently-unhandled": {
@@ -710,7 +710,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "dargs": {
@@ -719,7 +719,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "dateformat": {
@@ -740,8 +740,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "map-obj": {
@@ -770,7 +770,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.4"
       }
     },
     "delegates": {
@@ -791,7 +791,7 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "duplexer": {
@@ -812,7 +812,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -827,13 +827,13 @@
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "external-editor": {
@@ -842,9 +842,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.23",
+        "tmp": "0.0.33"
       }
     },
     "figures": {
@@ -853,7 +853,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "find-up": {
@@ -862,7 +862,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "fs-extra": {
@@ -871,9 +871,9 @@
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs.realpath": {
@@ -888,14 +888,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -904,7 +904,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -913,9 +913,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -932,11 +932,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "meow": "^3.3.0",
-        "normalize-package-data": "^2.3.0",
-        "parse-github-repo-url": "^1.3.0",
-        "through2": "^2.0.0"
+        "hosted-git-info": "2.6.0",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.4.0",
+        "parse-github-repo-url": "1.4.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -951,8 +951,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
+            "camelcase": "2.1.1",
+            "map-obj": "1.0.1"
           }
         },
         "indent-string": {
@@ -961,7 +961,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "map-obj": {
@@ -976,16 +976,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.4.0",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
           }
         },
         "minimist": {
@@ -1000,8 +1000,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
+            "indent-string": "2.1.0",
+            "strip-indent": "1.0.1"
           }
         },
         "strip-indent": {
@@ -1010,7 +1010,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1"
+            "get-stdin": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -1045,11 +1045,11 @@
       "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^4.0.2",
-        "meow": "^4.0.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0"
+        "dargs": "4.1.0",
+        "lodash.template": "4.4.0",
+        "meow": "4.0.1",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
       }
     },
     "git-remote-origin-url": {
@@ -1058,8 +1058,8 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -1076,8 +1076,8 @@
       "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
-        "meow": "^4.0.0",
-        "semver": "^5.5.0"
+        "meow": "4.0.1",
+        "semver": "5.5.0"
       }
     },
     "gitconfiglocal": {
@@ -1086,7 +1086,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.2"
+        "ini": "1.3.5"
       }
     },
     "glob": {
@@ -1095,12 +1095,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
@@ -1109,8 +1109,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       }
     },
     "globby": {
@@ -1119,11 +1119,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -1140,17 +1140,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -1165,10 +1165,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       }
     },
     "has-flag": {
@@ -1195,9 +1195,9 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "^1.0.10",
-        "normalize-path": "^1.0.0",
-        "strip-indent": "^2.0.0"
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
       },
       "dependencies": {
         "strip-indent": {
@@ -1214,7 +1214,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -1241,8 +1241,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1263,20 +1263,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1291,7 +1291,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1320,7 +1320,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -1329,7 +1329,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.1"
       }
     },
     "is-extglob": {
@@ -1344,7 +1344,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -1359,7 +1359,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-obj": {
@@ -1410,7 +1410,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "^1.0.0"
+        "text-extensions": "1.7.0"
       }
     },
     "is-utf8": {
@@ -1449,7 +1449,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonparse": {
@@ -1464,7 +1464,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -1480,7 +1480,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "lerna": {
@@ -1489,45 +1489,45 @@
       "integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
       "dev": true,
       "requires": {
-        "async": "^1.5.0",
-        "chalk": "^2.1.0",
-        "cmd-shim": "^2.0.2",
-        "columnify": "^1.5.4",
-        "command-join": "^2.0.0",
-        "conventional-changelog-cli": "^1.3.13",
-        "conventional-recommended-bump": "^1.2.1",
-        "dedent": "^0.7.0",
-        "execa": "^0.8.0",
-        "find-up": "^2.1.0",
-        "fs-extra": "^4.0.1",
-        "get-port": "^3.2.0",
-        "glob": "^7.1.2",
-        "glob-parent": "^3.1.0",
-        "globby": "^6.1.0",
-        "graceful-fs": "^4.1.11",
-        "hosted-git-info": "^2.5.0",
-        "inquirer": "^3.2.2",
-        "is-ci": "^1.0.10",
-        "load-json-file": "^4.0.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "npmlog": "^4.1.2",
-        "p-finally": "^1.0.0",
-        "package-json": "^4.0.1",
-        "path-exists": "^3.0.0",
-        "read-cmd-shim": "^1.0.1",
-        "read-pkg": "^3.0.0",
-        "rimraf": "^2.6.1",
-        "safe-buffer": "^5.1.1",
-        "semver": "^5.4.1",
-        "signal-exit": "^3.0.2",
-        "slash": "^1.0.0",
-        "strong-log-transformer": "^1.0.6",
-        "temp-write": "^3.3.0",
-        "write-file-atomic": "^2.3.0",
-        "write-json-file": "^2.2.0",
-        "write-pkg": "^3.1.0",
-        "yargs": "^8.0.2"
+        "async": "1.5.2",
+        "chalk": "2.4.1",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "command-join": "2.0.0",
+        "conventional-changelog-cli": "1.3.22",
+        "conventional-recommended-bump": "1.2.1",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-up": "2.1.0",
+        "fs-extra": "4.0.3",
+        "get-port": "3.2.0",
+        "glob": "7.1.2",
+        "glob-parent": "3.1.0",
+        "globby": "6.1.0",
+        "graceful-fs": "4.1.11",
+        "hosted-git-info": "2.6.0",
+        "inquirer": "3.3.0",
+        "is-ci": "1.0.10",
+        "load-json-file": "4.0.0",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "npmlog": "4.1.2",
+        "p-finally": "1.0.0",
+        "package-json": "4.0.1",
+        "path-exists": "3.0.0",
+        "read-cmd-shim": "1.0.1",
+        "read-pkg": "3.0.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "signal-exit": "3.0.2",
+        "slash": "1.0.0",
+        "strong-log-transformer": "1.0.6",
+        "temp-write": "3.4.0",
+        "write-file-atomic": "2.3.0",
+        "write-json-file": "2.3.0",
+        "write-pkg": "3.1.0",
+        "yargs": "8.0.2"
       }
     },
     "load-json-file": {
@@ -1536,10 +1536,10 @@
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -1548,8 +1548,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -1570,8 +1570,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -1580,7 +1580,7 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "longest": {
@@ -1595,8 +1595,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -1611,8 +1611,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
@@ -1621,7 +1621,7 @@
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "map-obj": {
@@ -1636,7 +1636,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "meow": {
@@ -1645,15 +1645,15 @@
       "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist": "^1.1.3",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0"
+        "camelcase-keys": "4.2.0",
+        "decamelize-keys": "1.1.0",
+        "loud-rejection": "1.6.0",
+        "minimist": "1.2.0",
+        "minimist-options": "3.0.2",
+        "normalize-package-data": "2.4.0",
+        "read-pkg-up": "3.0.0",
+        "redent": "2.0.0",
+        "trim-newlines": "2.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -1668,8 +1668,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         }
       }
@@ -1686,7 +1686,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1701,8 +1701,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "mkdirp": {
@@ -1744,10 +1744,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -1762,7 +1762,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -1771,10 +1771,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -1795,7 +1795,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -1804,7 +1804,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optimist": {
@@ -1813,8 +1813,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "os-locale": {
@@ -1823,9 +1823,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       },
       "dependencies": {
         "execa": {
@@ -1834,13 +1834,13 @@
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -1869,7 +1869,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.1.0"
       }
     },
     "package-json": {
@@ -1878,10 +1878,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       }
     },
     "parse-github-repo-url": {
@@ -1896,8 +1896,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.1",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "path-dirname": {
@@ -1930,7 +1930,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "pify": {
@@ -1951,7 +1951,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "prepend-http": {
@@ -1972,11 +1972,11 @@
       "integrity": "sha512-Q4V2GAflSaM739kKH63utbfI2n4s2fCDCyjFC4ykxA9ueb7FknLcLAZSKa3DejHMt5q9Fq395eKTZ9wYwoILBw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "execa": "^0.8.0",
-        "find-up": "^2.1.0",
-        "ignore": "^3.3.7",
-        "mri": "^1.1.0"
+        "chalk": "2.4.1",
+        "execa": "0.8.0",
+        "find-up": "2.1.0",
+        "ignore": "3.3.8",
+        "mri": "1.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1985,7 +1985,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.0"
           }
         },
         "chalk": {
@@ -1994,9 +1994,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -2011,7 +2011,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2046,10 +2046,10 @@
       "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.5.1",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.5.1",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -2066,7 +2066,7 @@
       "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2"
+        "graceful-fs": "4.1.11"
       }
     },
     "read-pkg": {
@@ -2075,9 +2075,9 @@
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
@@ -2086,8 +2086,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -2096,8 +2096,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "load-json-file": {
@@ -2106,11 +2106,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "parse-json": {
@@ -2119,7 +2119,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
@@ -2128,7 +2128,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -2137,9 +2137,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -2154,9 +2154,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "strip-bom": {
@@ -2165,7 +2165,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -2176,13 +2176,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "redent": {
@@ -2191,8 +2191,8 @@
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "indent-string": "^3.0.0",
-        "strip-indent": "^2.0.0"
+        "indent-string": "3.2.0",
+        "strip-indent": "2.0.0"
       }
     },
     "registry-auth-token": {
@@ -2201,8 +2201,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.7",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -2211,7 +2211,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.7"
       }
     },
     "repeat-string": {
@@ -2226,7 +2226,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "require-directory": {
@@ -2247,8 +2247,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "right-align": {
@@ -2258,7 +2258,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -2267,7 +2267,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "run-async": {
@@ -2276,7 +2276,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rx-lite": {
@@ -2291,7 +2291,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
@@ -2324,7 +2324,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -2351,7 +2351,7 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-map": {
@@ -2360,7 +2360,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "spdx-correct": {
@@ -2369,8 +2369,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -2385,8 +2385,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -2401,7 +2401,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split2": {
@@ -2410,7 +2410,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.2"
+        "through2": "2.0.3"
       }
     },
     "string-width": {
@@ -2419,8 +2419,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2435,7 +2435,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -2446,7 +2446,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -2455,7 +2455,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -2488,11 +2488,11 @@
       "integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
       "dev": true,
       "requires": {
-        "byline": "^5.0.0",
-        "duplexer": "^0.1.1",
-        "minimist": "^0.1.0",
-        "moment": "^2.6.0",
-        "through": "^2.3.4"
+        "byline": "5.0.0",
+        "duplexer": "0.1.1",
+        "minimist": "0.1.0",
+        "moment": "2.22.1",
+        "through": "2.3.8"
       },
       "dependencies": {
         "minimist": {
@@ -2509,7 +2509,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "temp-dir": {
@@ -2524,12 +2524,12 @@
       "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "is-stream": "^1.1.0",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.0.1"
+        "graceful-fs": "4.1.11",
+        "is-stream": "1.1.0",
+        "make-dir": "1.2.0",
+        "pify": "3.0.0",
+        "temp-dir": "1.0.0",
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "uuid": {
@@ -2546,8 +2546,8 @@
       "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "uuid": "^2.0.1"
+        "os-tmpdir": "1.0.2",
+        "uuid": "2.0.3"
       }
     },
     "text-extensions": {
@@ -2568,8 +2568,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "timed-out": {
@@ -2584,7 +2584,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "trim-newlines": {
@@ -2612,9 +2612,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -2631,9 +2631,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -2664,7 +2664,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "util-deprecate": {
@@ -2685,8 +2685,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "wcwidth": {
@@ -2695,7 +2695,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.3"
+        "defaults": "1.0.3"
       }
     },
     "which": {
@@ -2704,7 +2704,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -2719,7 +2719,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2728,7 +2728,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -2737,9 +2737,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -2763,8 +2763,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2773,7 +2773,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -2782,9 +2782,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -2801,9 +2801,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "write-json-file": {
@@ -2812,12 +2812,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "sort-keys": "^2.0.0",
-        "write-file-atomic": "^2.0.0"
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.2.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.3.0"
       }
     },
     "write-pkg": {
@@ -2826,8 +2826,8 @@
       "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
       "dev": true,
       "requires": {
-        "sort-keys": "^2.0.0",
-        "write-json-file": "^2.2.0"
+        "sort-keys": "2.0.0",
+        "write-json-file": "2.3.0"
       }
     },
     "xtend": {
@@ -2854,19 +2854,19 @@
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "read-pkg-up": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^7.0.0"
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2881,9 +2881,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -2892,9 +2892,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -2905,7 +2905,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "load-json-file": {
@@ -2914,10 +2914,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "parse-json": {
@@ -2926,7 +2926,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "path-type": {
@@ -2935,7 +2935,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "pify": {
@@ -2950,9 +2950,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -2961,8 +2961,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         }
       }
@@ -2973,7 +2973,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/packages/react-router-config/README.md
+++ b/packages/react-router-config/README.md
@@ -4,8 +4,8 @@ Static route configuration helpers for React Router.
 
 This is alpha software, it needs:
 
-1. Realistic server rendering example with data preloading
-2. Pending navigation example
+1.  Realistic server rendering example with data preloading
+2.  Pending navigation example
 
 ## Installation
 
@@ -17,10 +17,10 @@ Then with a module bundler like [webpack](https://webpack.github.io/), use as yo
 
 ```js
 // using an ES6 transpiler, like babel
-import { matchRoutes, renderRoutes } from 'react-router-config'
+import { matchRoutes, renderRoutes } from "react-router-config";
 
 // not using an ES6 transpiler
-var matchRoutes = require('react-router-config').matchRoutes
+var matchRoutes = require("react-router-config").matchRoutes;
 ```
 
 The UMD build is also available on [unpkg](https://unpkg.com):
@@ -35,9 +35,9 @@ You can find the library on `window.ReactRouterConfig`
 
 With the introduction of React Router v4, there is no longer a centralized route configuration. There are some use-cases where it is valuable to know about all the app's potential routes such as:
 
-- Loading data on the server or in the lifecycle before rendering the next screen
-- Linking to routes by name
-- Static analysis
+* Loading data on the server or in the lifecycle before rendering the next screen
+* Linking to routes by name
+* Static analysis
 
 This project seeks to define a shared format for others to build patterns on top of.
 
@@ -45,30 +45,34 @@ This project seeks to define a shared format for others to build patterns on top
 
 Routes are objects with the same properties as a `<Route>` with a couple differences:
 
-- the only render prop it accepts is `component` (no `render` or `children`)
-- introduces the `routes` key for sub routes
-- Consumers are free to add any additional props they'd like to a route, you can access `props.route` inside the `component`, this object is a reference to the object used to render and match.
-- accepts `key` prop to prevent remounting component when transition was made from route with the same component and same `key` prop
+* the only render prop it accepts is `component` (no `render` or `children`)
+* introduces the `routes` key for sub routes
+* Consumers are free to add any additional props they'd like to a route, you can access `props.route` inside the `component`, this object is a reference to the object used to render and match.
+* accepts `key` prop to prevent remounting component when transition was made from route with the same component and same `key` prop
 
 ```js
 const routes = [
-  { component: Root,
+  {
+    component: Root,
     routes: [
-      { path: '/',
+      {
+        path: "/",
         exact: true,
         component: Home
       },
-      { path: '/child/:id',
+      {
+        path: "/child/:id",
         component: Child,
         routes: [
-          { path: '/child/:id/grand-child',
+          {
+            path: "/child/:id/grand-child",
             component: GrandChild
           }
         ]
       }
     ]
   }
-]
+];
 ```
 
 **Note**: Just like `<Route>`, relative paths are not (yet) supported. When it is supported there, it will be supported here.
@@ -80,12 +84,13 @@ const routes = [
 Returns an array of matched routes.
 
 #### Parameters
-- routes - the route configuration
-- pathname - the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname) component of the url. This must be a decoded string representing the path.
+
+* routes - the route configuration
+* pathname - the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname) component of the url. This must be a decoded string representing the path.
 
 ```js
-import { matchRoutes } from 'react-router-config'
-const branch = matchRoutes(routes, '/child/23')
+import { matchRoutes } from "react-router-config";
+const branch = matchRoutes(routes, "/child/23");
 // using the routes shown earlier, this returns
 // [
 //   routes[0],
@@ -95,12 +100,12 @@ const branch = matchRoutes(routes, '/child/23')
 
 Each item in the array contains two properties: `routes` and `match`.
 
-- `routes`: A reference to the routes array used to match
-- `match`: The match object that also gets passed to `<Route>` render methods.
+* `routes`: A reference to the routes array used to match
+* `match`: The match object that also gets passed to `<Route>` render methods.
 
 ```js
-branch[0].match.url
-branch[0].match.isExact
+branch[0].match.url;
+branch[0].match.isExact;
 // etc.
 ```
 
@@ -134,18 +139,18 @@ class PendingNavDataLoader extends Component {
     previousLocation: null
   }
 
-  componentWillReceiveProps(nextProps) {
-    const navigated = nextProps.location !== this.props.location
+  componentDidUpdate(prevProps) {
+    const navigated = prevProps.location !== this.props.location
     const { routes } = this.props
 
     if (navigated) {
       // save the location so we can render the old screen
       this.setState({
-        previousLocation: this.props.location
+        previousLocation: prevProp.location
       })
 
       // load data while the old screen remains
-      loadNextData(routes, nextProps.location).then((data) => {
+      loadNextData(routes, this.props.location).then((data) => {
         putTheDataSomewhereRoutesCanFindIt(data)
         // clear previousLocation so the next screen renders
         this.setState({
@@ -191,26 +196,30 @@ Again, that's all pseudo-code. There are a lot of ways to do server rendering wi
 In order to ensure that matching outside of render with `matchRoutes` and inside of render result in the same branch, you must use `renderRoutes` instead of `<Route>` inside your components. You can render a `<Route>` still, but know that it will not be accounted for in `matchRoutes` outside of render.
 
 ```js
-import { renderRoutes } from 'react-router-config'
+import { renderRoutes } from "react-router-config";
 
 const routes = [
-  { component: Root,
+  {
+    component: Root,
     routes: [
-      { path: '/',
+      {
+        path: "/",
         exact: true,
         component: Home
       },
-      { path: '/child/:id',
+      {
+        path: "/child/:id",
         component: Child,
         routes: [
-          { path: '/child/:id/grand-child',
+          {
+            path: "/child/:id/grand-child",
             component: GrandChild
           }
         ]
       }
     ]
   }
-]
+];
 
 const Root = ({ route }) => (
   <div>
@@ -218,36 +227,34 @@ const Root = ({ route }) => (
     {/* child routes won't render without this */}
     {renderRoutes(route.routes)}
   </div>
-)
+);
 
 const Home = ({ route }) => (
   <div>
     <h2>Home</h2>
   </div>
-)
+);
 
 const Child = ({ route }) => (
   <div>
     <h2>Child</h2>
     {/* child routes won't render without this */}
-    {renderRoutes(route.routes, { someProp: 'these extra props are optional' })}
+    {renderRoutes(route.routes, { someProp: "these extra props are optional" })}
   </div>
-)
+);
 
 const GrandChild = ({ someProp }) => (
   <div>
     <h3>Grand Child</h3>
     <div>{someProp}</div>
   </div>
-)
+);
 
-
-ReactDOM.render((
+ReactDOM.render(
   <BrowserRouter>
     {/* kick it all off with the root route */}
     {renderRoutes(routes)}
-  </BrowserRouter>
-), document.getElementById('root'))
-
+  </BrowserRouter>,
+  document.getElementById("root")
+);
 ```
-

--- a/packages/react-router-dom/modules/BrowserRouter.js
+++ b/packages/react-router-dom/modules/BrowserRouter.js
@@ -18,7 +18,7 @@ class BrowserRouter extends React.Component {
 
   history = createHistory(this.props);
 
-  componentWillMount() {
+  componentDidMount() {
     warning(
       !this.props.history,
       "<BrowserRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router-dom/modules/HashRouter.js
+++ b/packages/react-router-dom/modules/HashRouter.js
@@ -17,7 +17,7 @@ class HashRouter extends React.Component {
 
   history = createHistory(this.props);
 
-  componentWillMount() {
+  componentDidMount() {
     warning(
       !this.props.history,
       "<HashRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router-native/docs/guides/animation.md
+++ b/packages/react-router-native/docs/guides/animation.md
@@ -5,7 +5,7 @@ This guide is a little sparse right now, but should provide enough insight to he
 # Element Transitions
 
 As the user navigates, some elements should animate while remaining on the
-page. The [`Route`][Route] `children` prop is perfect for these situations.
+page. The [`Route`][route] `children` prop is perfect for these situations.
 
 Consider this app without the router. When the `<TouchableHighlight/>` is pressed
 the sidebar's animation will toggle.
@@ -18,10 +18,10 @@ class Sidebar extends Component {
     )
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.isOpen !== this.props.isOpen) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.isOpen !== this.props.isOpen) {
       Animated.timing(this.state.anim, {
-        toValue: nextProps.isOpen ? 1 : 0
+        toValue: this.props.isOpen ? 1 : 0
       }).start()
     }
   }
@@ -60,18 +60,21 @@ class App extends Component {
   render() {
     return (
       <View>
-        <Route path="/sidebar" children={({ match }) => (
-          // `children` always renders, match or not. This
-          // way we can always render the sidebar, and then
-          // tell it if its open or not
-          <Sidebar isOpen={!!match}/>
-        )}/>
+        <Route
+          path="/sidebar"
+          children={({ match }) => (
+            // `children` always renders, match or not. This
+            // way we can always render the sidebar, and then
+            // tell it if its open or not
+            <Sidebar isOpen={!!match} />
+          )}
+        />
         <Link to="/sidebar">
           <Text>Open Sidebar</Text>
         </Link>
-        <Screen/>
+        <Screen />
       </View>
-    )
+    );
   }
 }
 ```
@@ -85,9 +88,7 @@ header.
 <View>
   {chutneys.map(chutney => (
     <Route path={`/chutney/${chutney.id}`}>
-      {({ match }) => (
-        <Chutney isActive={match}/>
-      )}
+      {({ match }) => <Chutney isActive={match} />}
     </Route>
   ))}
 </View>
@@ -97,9 +98,9 @@ Each chutney has its own route thats always rendering as part of the list, when 
 
 ## Page Transitions
 
-Because of components' declarative nature, when you're at one screen, press a link, and navigate to another, the old page is not in the render tree to even animate anymore! The key is remembering that React elements are just objects. You can save them and render them again.  That's the strategy for animating from one page (that leaves the render tree) to another.
+Because of components' declarative nature, when you're at one screen, press a link, and navigate to another, the old page is not in the render tree to even animate anymore! The key is remembering that React elements are just objects. You can save them and render them again. That's the strategy for animating from one page (that leaves the render tree) to another.
 
-If you visited this site on mobile, or you shrink the browser really small, you can click the back button to see this type of animation.  The strategy is to not think about animations at first. Just render your routes and links and make that all work, then wrap your components with animated components to spiff things up.
+If you visited this site on mobile, or you shrink the browser really small, you can click the back button to see this type of animation. The strategy is to not think about animations at first. Just render your routes and links and make that all work, then wrap your components with animated components to spiff things up.
 
 We'll consider some child routes in a page:
 
@@ -109,17 +110,16 @@ class Parent extends Component {
     return (
       <View>
         <Switch>
-          <Route path="/settings"/>
-          <Route path="/notifications"/>
+          <Route path="/settings" />
+          <Route path="/notifications" />
         </Switch>
       </View>
-    )
+    );
   }
 }
 ```
 
 Once that works without animations, we're ready to add an animation around it.
-
 
 ```jsx
 <AnimatedChild
@@ -128,98 +128,99 @@ Once that works without animations, we're ready to add an animation around it.
   animating={this.state.animating}
 >
   <Switch location={this.props.location}>
-    <Route path="/settings"/>
-    <Route path="/notifications"/>
+    <Route path="/settings" />
+    <Route path="/notifications" />
   </Switch>
 </AnimatedChild>
 ```
 
-It's important to use a [`<Switch>`][Switch]. It will ensure that only one route can match, and therefore gives us a single element on `props.children` to hang on to and render during the animation. Finally, you *must* pass the location to `Switch`. It prefers `props.location` over the internal router location, which enables the saved child element to be renered later and continue to match the old location.
+It's important to use a [`<Switch>`][switch]. It will ensure that only one route can match, and therefore gives us a single element on `props.children` to hang on to and render during the animation. Finally, you _must_ pass the location to `Switch`. It prefers `props.location` over the internal router location, which enables the saved child element to be renered later and continue to match the old location.
 
 There are a handful of props handed to `AnimatedChild` that the parent will know about as it manages the animation. Again, this guide is more inspiration than copy/paste right now, feel free to look at the source of this website for exact implementation. Alright, let's check out the implementation of `AnimatedChild` (it's copy pasted from the animation used on this site).
 
 ```jsx
 class AnimatedChild extends Component {
-
   static propTypes = {
     children: PropTypes.node,
     anim: PropTypes.object,
     atParent: PropTypes.bool,
     animating: PropTypes.bool
-  }
+  };
 
   state = {
     // we're going to save the old children so we can render
     // it when it doesnt' actually match the location anymore
     previousChildren: null
-  }
+  };
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     // figure out what to do with the children
-    const navigatingToParent = nextProps.atParent && !this.props.atParent
-    const animationEnded = this.props.animating && !nextProps.animating
+    const navigatingToParent = prevProps.atParent && !this.props.atParent;
+    const animationEnded = this.props.animating && !prevProps.animating;
 
     if (navigatingToParent) {
       // we were rendering, but now we're heading back up to the parent,
       // so we need to save the children (har har) so we can render them
       // while the animation is playing
       this.setState({
-        previousChildren: this.props.children
-      })
+        previousChildren: prevProps.children
+      });
     } else if (animationEnded) {
       // When we're done animating, we can get rid of the old children.
       this.setState({
         previousChildren: null
-      })
+      });
     }
   }
 
   render() {
-    const { anim, children } = this.props
-    const { previousChildren } = this.state
+    const { anim, children } = this.props;
+    const { previousChildren } = this.state;
     return (
-      <Animated.View style={{
-        position: 'absolute',
-        left: 0,
-        right: 0,
-        top: anim.interpolate({
-          inputRange: [ 0, 1 ],
-          outputRange: [ 20, 0 ]
-        }),
-        opacity: anim.interpolate({
-          inputRange: [ 0, 0.75 ],
-          outputRange: [ 0, 1 ]
-        })
-      }}>
+      <Animated.View
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          top: anim.interpolate({
+            inputRange: [0, 1],
+            outputRange: [20, 0]
+          }),
+          opacity: anim.interpolate({
+            inputRange: [0, 0.75],
+            outputRange: [0, 1]
+          })
+        }}
+      >
         {/* render the old ones if we have them */}
         {previousChildren || children}
       </Animated.View>
-    )
+    );
   }
 }
 ```
 
-Hope that helps get you thinking. Again, the animations themselves are the same with the router or not, the difference is knowing when to trigger them. Here's a list for things to check in `componentWillReceiveProps` to decide what to do with an animation based on the router's location:
+Hope that helps get you thinking. Again, the animations themselves are the same with the router or not, the difference is knowing when to trigger them. Here's a list for things to check in `componentDidUpdate` to decide what to do with an animation based on the router's location:
 
 General change in location
 
 ```js
-nextProps.location !== this.props.location`
+prevProps.location !== this.props.location`
 ```
 
 Going from child to parent:
 
 ```js
-nextProps.match.isExact && !this.props.match.isExact
+prevProps.match.isExact && !this.props.match.isExact;
 ```
 
 Going from parent to child:
 
 ```js
-!nextProps.match.isExact && this.props.match.isExact
+!prevProps.match.isExact && this.props.match.isExact;
 ```
 
 Good luck! We hope to expand on this section with a lot more detail and live examples.
 
-  [Route]:../api/Route.md
-  [Switch]:../api/Switch.md
+[route]: ../api/Route.md
+[switch]: ../api/Switch.md

--- a/packages/react-router-native/experimental/StackRoute.js
+++ b/packages/react-router-native/experimental/StackRoute.js
@@ -5,8 +5,8 @@
 // Any help cleaning it up would be appreciated.
 // <3 <3 <3 - Ryan
 
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import {
   Text,
@@ -17,27 +17,27 @@ import {
   Dimensions,
   Animated,
   PanResponder
-} from 'react-native'
+} from "react-native";
 
-import Route from 'react-router/Route'
-import Redirect from 'react-router/Redirect'
-import Link from '../Link'
+import Route from "react-router/Route";
+import Redirect from "react-router/Redirect";
+import Link from "../Link";
 
-const { any, node } = PropTypes
+const { any, node } = PropTypes;
 
 class StackContainer extends Component {
   static contextTypes = {
     stack: any
-  }
+  };
 
   static childContextTypes = {
     stack: any
-  }
+  };
 
   initialLocation = {
     ...this.props.location,
     pathname: this.props.match.url
-  }
+  };
 
   getChildContext() {
     return {
@@ -45,51 +45,49 @@ class StackContainer extends Component {
         ...this.context.stack,
         parentLocation: this.initialLocation
       }
-    }
+    };
   }
 
-  componentWillMount() {
-    this.pushToStack('down')
+  componentDidMount() {
+    this.pushToStack("down");
   }
 
   componentDidUpdate(prevProps) {
-    const becameActive = (
-      this.props.match.isExact === true &&
-      prevProps.match.isExact === false
-    )
+    const becameActive =
+      this.props.match.isExact === true && prevProps.match.isExact === false;
 
     if (becameActive) {
-      this.pushToStack('up')
+      this.pushToStack("up");
     }
   }
 
   pushToStack(direction) {
-    const { renderTitle, renderContent, renderChild, ...rest } = this.props
-    const { match } = rest
+    const { renderTitle, renderContent, renderChild, ...rest } = this.props;
+    const { match } = rest;
     if (match && match.isExact) {
       this.context.stack.push({
         title: renderTitle(rest),
         content: renderContent(rest),
         parentLocation: this.context.stack.parentLocation,
         direction
-      })
+      });
     }
   }
 
   render() {
-    const { renderTitle, renderContent, renderChild, ...rest } = this.props
-    const { match } = rest
-    return match.isExact ? null : renderChild ? renderChild(rest) : null
+    const { renderTitle, renderContent, renderChild, ...rest } = this.props;
+    const { match } = rest;
+    return match.isExact ? null : renderChild ? renderChild(rest) : null;
   }
 }
 
-const ANIMATION_DURATION = 300
-const CANCEL_PAN_MOVE_THRESHOLD = 0.5
-const CANCEL_PAN_VX_THRESHOLD = 0.5
-const PAN_START_MARGIN = 30
-const PARENT_TRAVEL_DISTANCE = 100
-const PARENT_FINAL_OPACITY = 0.25
-const CARD_SHADOW_RADIUS = 10
+const ANIMATION_DURATION = 300;
+const CANCEL_PAN_MOVE_THRESHOLD = 0.5;
+const CANCEL_PAN_VX_THRESHOLD = 0.5;
+const PAN_START_MARGIN = 30;
+const PARENT_TRAVEL_DISTANCE = 100;
+const PARENT_FINAL_OPACITY = 0.25;
+const CARD_SHADOW_RADIUS = 10;
 
 class AnimatedStack extends React.Component {
   static propTypes = {
@@ -100,264 +98,286 @@ class AnimatedStack extends React.Component {
     location: any,
     onPanBackGrant: any,
     onCancelPan: any
-  }
+  };
 
   state = {
     previousProps: null,
     panning: false,
     cancelingPan: false
-  }
+  };
 
-  animation = new Animated.Value(0)
+  animation = new Animated.Value(0);
 
   panResponder = PanResponder.create({
-
     onMoveShouldSetPanResponderCapture: (e, g) => {
       return (
         this.props.parentLocation &&
         e.nativeEvent.locationX <= PAN_START_MARGIN &&
         g.dx > 0
-      )
+      );
     },
 
     onPanResponderGrant: (e, g) => {
-      this.setState({
-        startPan: true,
-        panStartLeft: g.moveX
-      }, () => {
-        this.props.onPanBackGrant()
-      })
+      this.setState(
+        {
+          startPan: true,
+          panStartLeft: g.moveX
+        },
+        () => {
+          this.props.onPanBackGrant();
+        }
+      );
     },
 
-    onPanResponderMove: Animated.event([ null, { moveX: this.animation } ]),
+    onPanResponderMove: Animated.event([null, { moveX: this.animation }]),
 
     onPanResponderRelease: (e, g) => {
-      const { panStartLeft } = this.state
-      const { width } = Dimensions.get('window')
-      const releaseRatio = g.moveX/width
-      const isCancel = g.vx < CANCEL_PAN_VX_THRESHOLD && releaseRatio < CANCEL_PAN_MOVE_THRESHOLD
+      const { panStartLeft } = this.state;
+      const { width } = Dimensions.get("window");
+      const releaseRatio = g.moveX / width;
+      const isCancel =
+        g.vx < CANCEL_PAN_VX_THRESHOLD &&
+        releaseRatio < CANCEL_PAN_MOVE_THRESHOLD;
       if (isCancel) {
-        this.animation.setValue(g.moveX - panStartLeft)
-        this.setState({
-          panning: false,
-          cancelingPan: true
-        }, () => {
-          Animated.timing(this.animation, {
-            toValue: 0,
-            duration: releaseRatio * ANIMATION_DURATION + 2000
-          }).start(({ finished }) => {
-            this.props.onCancelPan()
-          })
-        })
+        this.animation.setValue(g.moveX - panStartLeft);
+        this.setState(
+          {
+            panning: false,
+            cancelingPan: true
+          },
+          () => {
+            Animated.timing(this.animation, {
+              toValue: 0,
+              duration: releaseRatio * ANIMATION_DURATION + 2000
+            }).start(({ finished }) => {
+              this.props.onCancelPan();
+            });
+          }
+        );
       } else {
-        this.animation.setValue(g.moveX - panStartLeft)
+        this.animation.setValue(g.moveX - panStartLeft);
         this.setState({ panning: false }, () => {
           Animated.timing(this.animation, {
             toValue: width,
-            duration: (1-releaseRatio) * ANIMATION_DURATION + 2000
+            duration: (1 - releaseRatio) * ANIMATION_DURATION + 2000
           }).start(({ finished }) => {
             this.setState({
               previousProps: null
-            })
-          })
-        })
+            });
+          });
+        });
       }
     }
-  })
+  });
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.location !== this.props.location) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.location !== this.props.location) {
       if (this.state.cancelingPan) {
         // location comes in after the animation is done,
         // so we remove previousProps after the router transition
         this.setState({
           cancelingPan: false,
           previousProps: null
-        })
+        });
       } else if (this.state.startPan) {
         // don't do "timing" animation when we start to pan, let
         // the user slide it around
         this.setState({
           startPan: false,
           panning: true,
-          previousProps: this.props
-        })
+          previousProps: prevProps
+        });
       } else {
         // normal case, new location shows up, so we animate
-        const { width } = Dimensions.get('window')
-        this.setState({
-          previousProps: this.props
-        }, () => {
-          this.animation.setValue(0)
-          Animated.timing(this.animation, {
-            toValue: width,
-            duration: ANIMATION_DURATION
-          }).start(({ finished }) => {
-            this.setState({ previousProps: null })
-          })
-        })
+        const { width } = Dimensions.get("window");
+        this.setState(
+          {
+            previousProps: prevProps
+          },
+          () => {
+            this.animation.setValue(0);
+            Animated.timing(this.animation, {
+              toValue: width,
+              duration: ANIMATION_DURATION
+            }).start(({ finished }) => {
+              this.setState({ previousProps: null });
+            });
+          }
+        );
       }
     }
   }
 
   render() {
-    const { width, height } = Dimensions.get('window')
-    const { direction } = this.props
-    const { previousProps, panDx, panning, panStartLeft } = this.state
-    const animating = !!previousProps
-    const bothProps = [ this.props ]
-    if (animating)
-      bothProps.push(previousProps)
+    const { width, height } = Dimensions.get("window");
+    const { direction } = this.props;
+    const { previousProps, panDx, panning, panStartLeft } = this.state;
+    const animating = !!previousProps;
+    const bothProps = [this.props];
+    if (animating) bothProps.push(previousProps);
 
     return (
       <View
-        pointerEvents={animating ? 'none' : 'auto'}
-        style={{ flex: 1  }}
+        pointerEvents={animating ? "none" : "auto"}
+        style={{ flex: 1 }}
         {...this.panResponder.panHandlers}
       >
-        <View style={{ zIndex: 1, backgroundColor: '#f0f0f0', borderBottomColor: '#ccc', borderBottomWidth: 1, height: 40, alignItems: 'center' }}>
+        <View
+          style={{
+            zIndex: 1,
+            backgroundColor: "#f0f0f0",
+            borderBottomColor: "#ccc",
+            borderBottomWidth: 1,
+            height: 40,
+            alignItems: "center"
+          }}
+        >
           {bothProps.map((props, index, arr) => {
-            const isParent = index === 0
-            const transitioning = arr.length > 1
+            const isParent = index === 0;
+            const transitioning = arr.length > 1;
             return (
               <Animated.View
                 key={props.location.pathname}
                 style={{
-                  opacity: (
-                    !transitioning ? (
-                      1
-                    ) : isParent ? (
-                      this.animation.interpolate({
-                        inputRange: [ 0, width ],
-                        outputRange: [ 0, 1 ]
-                      })
-                    ) : (
-                      this.animation.interpolate({
-                        inputRange: [ 0, width ],
-                        outputRange: [ 1, 0 ]
-                      })
-                    )
-                  ),
-                  flexDirection: 'row', alignItems: 'center', position: 'absolute', top: 0, left: 0, right: 0, bottom: 0
+                  opacity: !transitioning
+                    ? 1
+                    : isParent
+                      ? this.animation.interpolate({
+                          inputRange: [0, width],
+                          outputRange: [0, 1]
+                        })
+                      : this.animation.interpolate({
+                          inputRange: [0, width],
+                          outputRange: [1, 0]
+                        }),
+                  flexDirection: "row",
+                  alignItems: "center",
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0
                 }}
               >
                 <View style={{ width: 30 }}>
-                  {props.parentLocation ? props.backButton : <Text>&nbsp;</Text>}
+                  {props.parentLocation ? (
+                    props.backButton
+                  ) : (
+                    <Text>&nbsp;</Text>
+                  )}
                 </View>
-                <View style={{ flex: 1 }}>
-                  {props.title}
-                </View>
-                <View style={{ width: 30 }}/>
+                <View style={{ flex: 1 }}>{props.title}</View>
+                <View style={{ width: 30 }} />
               </Animated.View>
-            )
+            );
           })}
         </View>
-        <View style={{ flex: 1, backgroundColor: '#ccc' }}>
+        <View style={{ flex: 1, backgroundColor: "#ccc" }}>
           {bothProps.map((props, index, arr) => {
-            const isParent = index === 0
-            const transitioning = arr.length > 1
+            const isParent = index === 0;
+            const transitioning = arr.length > 1;
             return (
-              <Animated.View key={props.location.pathname} style={{
-                transform: [{ translateX: !transitioning ? (
-                  0
-                ) : panning ? (
-                  isParent ? (
-                    this.animation.interpolate({
-                      inputRange: [ 0, width ],
-                      outputRange: [
-                        -PARENT_TRAVEL_DISTANCE - panStartLeft,
-                        -panStartLeft
-                      ]
-                    })
-                  ) : (
-                    this.animation.interpolate({
-                      inputRange: [ 0, width ],
-                      outputRange: [
-                        -panStartLeft,
-                        width-panStartLeft
-                      ]
-                    })
-                  )
-                ) : (
-                  this.animation.interpolate({
-                    inputRange: [ 0, width ],
-                    outputRange: (
-                      isParent ? (
-                        direction === 'down' ? (
-                          [ width + CARD_SHADOW_RADIUS, 0 ]
-                        ) : (
-                          [ -PARENT_TRAVEL_DISTANCE, 0 ]
-                        )
-                      ) : (
-                        direction === 'down' ? (
-                          [ 0, -PARENT_TRAVEL_DISTANCE ]
-                        ) : (
-                          [ 0, width + CARD_SHADOW_RADIUS ]
-                        )
-                      )
-                    )
-                  })
-                ) }],
-                zIndex: !transitioning ? 1 : (
-                  isParent ? (
-                    direction === 'down' ? 1 : 0
-                  ) : (
-                    direction === 'down' ? 0 : 1
-                  )
-                ),
-                position: 'absolute', width, height, top: 0,
-                shadowColor: "#000000",
-                shadowOpacity: 0.25,
-                shadowRadius: CARD_SHADOW_RADIUS,
-                opacity: panning ? (
-                  !isParent ? 1 : (
-                    this.animation.interpolate({
-                      inputRange: [ 0, width ],
-                      outputRange: [ PARENT_FINAL_OPACITY, 1 ]
-                    })
-                  )
-                ) : (
-                  !transitioning ? 1 : isParent && 'direction' === 'down' ? 1 : (
-                    this.animation.interpolate({
-                      inputRange: [ 0, width ],
-                      outputRange: (
-                        index === 1 && direction === 'down' ? (
-                          [ 1, PARENT_FINAL_OPACITY ]
-                        ) : isParent && direction === 'up' ? (
-                          [ PARENT_FINAL_OPACITY, 1 ]
-                        ) : index === 1 && direction === 'up' ? (
-                          [ 1, 1 ]
-                        ) : [1, 1]
-                      )
-                    })
-                  )
-                )
-              }}>
+              <Animated.View
+                key={props.location.pathname}
+                style={{
+                  transform: [
+                    {
+                      translateX: !transitioning
+                        ? 0
+                        : panning
+                          ? isParent
+                            ? this.animation.interpolate({
+                                inputRange: [0, width],
+                                outputRange: [
+                                  -PARENT_TRAVEL_DISTANCE - panStartLeft,
+                                  -panStartLeft
+                                ]
+                              })
+                            : this.animation.interpolate({
+                                inputRange: [0, width],
+                                outputRange: [
+                                  -panStartLeft,
+                                  width - panStartLeft
+                                ]
+                              })
+                          : this.animation.interpolate({
+                              inputRange: [0, width],
+                              outputRange: isParent
+                                ? direction === "down"
+                                  ? [width + CARD_SHADOW_RADIUS, 0]
+                                  : [-PARENT_TRAVEL_DISTANCE, 0]
+                                : direction === "down"
+                                  ? [0, -PARENT_TRAVEL_DISTANCE]
+                                  : [0, width + CARD_SHADOW_RADIUS]
+                            })
+                    }
+                  ],
+                  zIndex: !transitioning
+                    ? 1
+                    : isParent
+                      ? direction === "down"
+                        ? 1
+                        : 0
+                      : direction === "down"
+                        ? 0
+                        : 1,
+                  position: "absolute",
+                  width,
+                  height,
+                  top: 0,
+                  shadowColor: "#000000",
+                  shadowOpacity: 0.25,
+                  shadowRadius: CARD_SHADOW_RADIUS,
+                  opacity: panning
+                    ? !isParent
+                      ? 1
+                      : this.animation.interpolate({
+                          inputRange: [0, width],
+                          outputRange: [PARENT_FINAL_OPACITY, 1]
+                        })
+                    : !transitioning
+                      ? 1
+                      : isParent && "direction" === "down"
+                        ? 1
+                        : this.animation.interpolate({
+                            inputRange: [0, width],
+                            outputRange:
+                              index === 1 && direction === "down"
+                                ? [1, PARENT_FINAL_OPACITY]
+                                : isParent && direction === "up"
+                                  ? [PARENT_FINAL_OPACITY, 1]
+                                  : index === 1 && direction === "up"
+                                    ? [1, 1]
+                                    : [1, 1]
+                          })
+                }}
+              >
                 {props.content}
               </Animated.View>
-          )})}
+            );
+          })}
         </View>
       </View>
-    )
+    );
   }
 }
 
-const rootStoredLocations = {}
+const rootStoredLocations = {};
 
 class StackRootContainer extends Component {
   static childContextTypes = {
-    stack: any,
-  }
+    stack: any
+  };
 
   static contextTypes = {
     router: PropTypes.object
-  }
+  };
 
   static propTypes = {
     children: PropTypes.node,
     location: PropTypes.object,
     path: PropTypes.string
-  }
+  };
 
   state = {
     title: null,
@@ -365,7 +385,7 @@ class StackRootContainer extends Component {
     backLocation: null,
     backButton: null,
     direction: null
-  }
+  };
 
   getChildContext() {
     return {
@@ -381,30 +401,36 @@ class StackRootContainer extends Component {
                 <Text style={{ padding: 10 }}>&lt;</Text>
               </Link>
             ) : null
-          })
+          });
         }
       }
-    }
+    };
   }
 
   componentWillUnmount() {
-    rootStoredLocations[this.props.path] = this.props.location
+    rootStoredLocations[this.props.path] = this.props.location;
   }
 
   handlePanBack = () => {
     if (this.state.parentLocation) {
-      this.panCancelLocation = this.props.location
-      this.context.router.history.replace(this.state.parentLocation)
+      this.panCancelLocation = this.props.location;
+      this.context.router.history.replace(this.state.parentLocation);
     }
-  }
+  };
 
   handlePanCancel = () => {
-    this.context.router.history.replace(this.panCancelLocation)
-  }
+    this.context.router.history.replace(this.panCancelLocation);
+  };
 
   render() {
-    const { title, content, backButton, parentLocation, direction } = this.state
-    const { children, location } = this.props
+    const {
+      title,
+      content,
+      backButton,
+      parentLocation,
+      direction
+    } = this.state;
+    const { children, location } = this.props;
 
     return (
       <View style={{ flex: 1 }}>
@@ -420,17 +446,17 @@ class StackRootContainer extends Component {
         />
         {children}
       </View>
-    )
+    );
   }
 }
 
 class RedirectStack extends Component {
-  componentWillMount() {
-    delete rootStoredLocations[this.props.path]
+  componentDidMount() {
+    delete rootStoredLocations[this.props.path];
   }
 
   render() {
-    return <Redirect to={this.props.to}/>
+    return <Redirect to={this.props.to} />;
   }
 }
 
@@ -441,26 +467,29 @@ class StackRoute extends Component {
     renderTitle: any,
     renderContent: any,
     renderChild: any
-  }
+  };
 
   render() {
-    const { isRoot, path, ...rest } = this.props
+    const { isRoot, path, ...rest } = this.props;
     return (
-      <Route path={path} render={(props) => (
-        isRoot ? (
-          rootStoredLocations[path] ? (
-            <RedirectStack path={path} to={rootStoredLocations[path]}/>
+      <Route
+        path={path}
+        render={props =>
+          isRoot ? (
+            rootStoredLocations[path] ? (
+              <RedirectStack path={path} to={rootStoredLocations[path]} />
+            ) : (
+              <StackRootContainer path={path} location={props.location}>
+                <StackContainer {...rest} {...props} />
+              </StackRootContainer>
+            )
           ) : (
-            <StackRootContainer path={path} location={props.location}>
-              <StackContainer {...rest} {...props}/>
-            </StackRootContainer>
+            <StackContainer {...rest} {...props} />
           )
-        ) : (
-          <StackContainer {...rest} {...props}/>
-        )
-      )}/>
-    )
+        }
+      />
+    );
   }
 }
 
-export default StackRoute
+export default StackRoute;

--- a/packages/react-router-native/package-lock.json
+++ b/packages/react-router-native/package-lock.json
@@ -22,14 +22,14 @@
 				"@babel/traverse": "7.0.0-beta.46",
 				"@babel/types": "7.0.0-beta.46",
 				"babylon": "7.0.0-beta.46",
-				"convert-source-map": "^1.1.0",
-				"debug": "^3.1.0",
-				"json5": "^0.5.0",
-				"lodash": "^4.2.0",
-				"micromatch": "^2.3.11",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
+				"convert-source-map": "1.5.1",
+				"debug": "3.1.0",
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"micromatch": "2.3.11",
+				"resolve": "1.7.1",
+				"semver": "5.5.0",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -37,7 +37,7 @@
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -55,9 +55,9 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"debug": {
@@ -73,7 +73,7 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -81,7 +81,7 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -89,7 +89,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -97,19 +97,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"resolve": {
@@ -117,7 +117,7 @@
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 					"requires": {
-						"path-parse": "^1.0.5"
+						"path-parse": "1.0.5"
 					}
 				}
 			}
@@ -128,10 +128,10 @@
 			"integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
 			"requires": {
 				"@babel/types": "7.0.0-beta.46",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.2.0",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"jsesc": "2.5.1",
+				"lodash": "4.17.4",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -164,7 +164,7 @@
 			"integrity": "sha512-4xakEEfimusXNgpSY6rP7robwRcnv1E8OxjkYSfsZCYsomFwN7RXU5S29vGWzxE37Yua4yTFqBwId9lwF84Hzw==",
 			"requires": {
 				"@babel/types": "7.0.0-beta.46",
-				"esutils": "^2.0.0"
+				"esutils": "2.0.2"
 			}
 		},
 		"@babel/helper-call-delegate": {
@@ -184,7 +184,7 @@
 			"requires": {
 				"@babel/helper-function-name": "7.0.0-beta.46",
 				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.4"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -236,7 +236,7 @@
 			"integrity": "sha512-xjgpwrqHiKCZgAcqsNIpZ9kOCC5Ty/VYN1H07v21HbAf/dl0/HeUA0taz3EFv6/7lRgS3qThawTSG0POJQX9vQ==",
 			"requires": {
 				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.4"
 			}
 		},
 		"@babel/helper-module-transforms": {
@@ -249,7 +249,7 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
 				"@babel/template": "7.0.0-beta.46",
 				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.4"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -295,7 +295,7 @@
 			"requires": {
 				"@babel/template": "7.0.0-beta.46",
 				"@babel/types": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -332,9 +332,9 @@
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
 			"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"chalk": "2.4.1",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -342,7 +342,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -350,9 +350,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -360,7 +360,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -447,7 +447,7 @@
 			"integrity": "sha512-7OwS0ObI6nLacEKP1HCdnoIQnHBqOV6IgtKGiPO+Nj03OnZ1Yo2aeK9sfOtwL43aNztnKqFVt2L5PfZg4VGidA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.4"
 			}
 		},
 		"@babel/plugin-transform-classes": {
@@ -462,7 +462,7 @@
 				"@babel/helper-plugin-utils": "7.0.0-beta.46",
 				"@babel/helper-replace-supers": "7.0.0-beta.46",
 				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
-				"globals": "^11.1.0"
+				"globals": "11.4.0"
 			},
 			"dependencies": {
 				"globals": {
@@ -591,7 +591,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.46.tgz",
 			"integrity": "sha512-P6d8ckSjKlbr/1SL1NBO6ieFxSebTiRWd2R8/styUIizJWQlEB0ITQ7l8vv3jXGjJ0mh7lxBTegXejRkTGKKgw==",
 			"requires": {
-				"regenerator-transform": "^0.12.3"
+				"regenerator-transform": "0.12.3"
 			},
 			"dependencies": {
 				"regenerator-transform": {
@@ -599,7 +599,7 @@
 					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.3.tgz",
 					"integrity": "sha512-y2uxO/6u+tVmtEDIKo+tLCtI0GcbQr0OreosKgCd7HP4VypGjtTrw79DezuwT+W5QX0YWuvpeBOgumrepwM1kA==",
 					"requires": {
-						"private": "^0.1.6"
+						"private": "0.1.8"
 					}
 				}
 			}
@@ -634,13 +634,13 @@
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.46.tgz",
 			"integrity": "sha512-S43PemtH5CSDE9GJesjUoAQGfC2rwLcc35gq/y6WQHPzWOd90yOvKydUk/pS7aSMrDiJSXYtyEeZFsq/8dtLhg==",
 			"requires": {
-				"core-js": "^2.5.3",
-				"find-cache-dir": "^1.0.0",
-				"home-or-tmp": "^3.0.0",
-				"lodash": "^4.2.0",
-				"mkdirp": "^0.5.1",
-				"pirates": "^3.0.1",
-				"source-map-support": "^0.4.2"
+				"core-js": "2.5.5",
+				"find-cache-dir": "1.0.0",
+				"home-or-tmp": "3.0.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"pirates": "3.0.2",
+				"source-map-support": "0.4.18"
 			},
 			"dependencies": {
 				"core-js": {
@@ -658,7 +658,7 @@
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"requires": {
-						"source-map": "^0.5.6"
+						"source-map": "0.5.7"
 					}
 				}
 			}
@@ -671,7 +671,7 @@
 				"@babel/code-frame": "7.0.0-beta.46",
 				"@babel/types": "7.0.0-beta.46",
 				"babylon": "7.0.0-beta.46",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.4"
 			},
 			"dependencies": {
 				"babylon": {
@@ -692,10 +692,10 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
 				"@babel/types": "7.0.0-beta.46",
 				"babylon": "7.0.0-beta.46",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
+				"debug": "3.1.0",
+				"globals": "11.4.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.4"
 			},
 			"dependencies": {
 				"babylon": {
@@ -723,9 +723,9 @@
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
 			"integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^2.0.0"
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "2.0.0"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -745,7 +745,7 @@
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"requires": {
-				"mime-types": "~2.1.18",
+				"mime-types": "2.1.18",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -759,7 +759,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
 			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
 			"requires": {
-				"ansi-wrap": "^0.1.0"
+				"ansi-wrap": "0.1.0"
 			}
 		},
 		"ansi-cyan": {
@@ -811,8 +811,8 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"arch": {
@@ -825,8 +825,8 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"arr-diff": {
@@ -889,7 +889,7 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 			"requires": {
-				"lodash": "^4.14.0"
+				"lodash": "4.17.4"
 			}
 		},
 		"atob": {
@@ -902,9 +902,9 @@
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"babel-core": {
@@ -912,25 +912,25 @@
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.2.tgz",
 			"integrity": "sha512-rFKFnHY8sbRSqja2O5eTx0z0Na5hukdtsFt7X9xdBFXMurrJ5YoY78Y/2/EuNZIaDQKEJSfxSMePfsymxt0CZg==",
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			}
 		},
 		"babel-generator": {
@@ -938,14 +938,14 @@
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.4",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -953,9 +953,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -963,9 +963,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"esutils": "2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -973,10 +973,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-define-map": {
@@ -984,10 +984,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -995,9 +995,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -1005,11 +1005,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -1017,8 +1017,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -1026,8 +1026,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -1035,8 +1035,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -1044,9 +1044,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -1054,11 +1054,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -1066,12 +1066,12 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -1079,8 +1079,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-messages": {
@@ -1088,7 +1088,7 @@
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -1096,7 +1096,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-external-helpers": {
@@ -1104,7 +1104,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-react-transform": {
@@ -1112,7 +1112,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
 			"integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
 			"requires": {
-				"lodash": "^4.6.1"
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -1160,9 +1160,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
 			"integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.16.0",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.0.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1170,10 +1170,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1181,7 +1181,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1189,7 +1189,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1197,11 +1197,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1209,15 +1209,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1225,8 +1225,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1234,7 +1234,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1242,7 +1242,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1250,9 +1250,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1260,7 +1260,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1268,10 +1268,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1279,8 +1279,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1288,12 +1288,12 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1301,8 +1301,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1310,7 +1310,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1318,9 +1318,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1328,7 +1328,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1336,9 +1336,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-es3-member-expression-literals": {
@@ -1346,7 +1346,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
 			"integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es3-property-literals": {
@@ -1354,7 +1354,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
 			"integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1362,9 +1362,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1372,8 +1372,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-assign": {
@@ -1381,7 +1381,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
 			"integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1389,8 +1389,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -1398,7 +1398,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -1406,9 +1406,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-react-jsx": "6.26.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -1416,8 +1416,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1425,7 +1425,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
-				"regenerator-transform": "^0.10.0"
+				"regenerator-transform": "0.10.1"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1433,8 +1433,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-preset-es2015-node": {
@@ -1442,15 +1442,15 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015-node/-/babel-preset-es2015-node-6.1.1.tgz",
 			"integrity": "sha1-YLIxVwJLDP6/OmNVTLBe4DW05V8=",
 			"requires": {
-				"babel-plugin-transform-es2015-destructuring": "6.x",
-				"babel-plugin-transform-es2015-function-name": "6.x",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.x",
-				"babel-plugin-transform-es2015-parameters": "6.x",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.x",
-				"babel-plugin-transform-es2015-spread": "6.x",
-				"babel-plugin-transform-es2015-sticky-regex": "6.x",
-				"babel-plugin-transform-es2015-unicode-regex": "6.x",
-				"semver": "5.x"
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"semver": "5.5.0"
 			}
 		},
 		"babel-preset-fbjs": {
@@ -1458,34 +1458,34 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz",
 			"integrity": "sha512-6XVQwlO26V5/0P9s2Eje8Epqkv/ihaMJ798+W98ktOA8fCn2IFM6wEi7CDW3fTbKFZ/8fDGvGZH01B6GSuNiWA==",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.8.0",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-plugin-syntax-flow": "^6.8.0",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.8.0",
-				"babel-plugin-transform-class-properties": "^6.8.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.8.0",
-				"babel-plugin-transform-es2015-classes": "^6.8.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.8.0",
-				"babel-plugin-transform-es2015-for-of": "^6.8.0",
-				"babel-plugin-transform-es2015-function-name": "^6.8.0",
-				"babel-plugin-transform-es2015-literals": "^6.8.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
-				"babel-plugin-transform-es2015-object-super": "^6.8.0",
-				"babel-plugin-transform-es2015-parameters": "^6.8.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-				"babel-plugin-transform-es2015-spread": "^6.8.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.8.0",
-				"babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
-				"babel-plugin-transform-es3-property-literals": "^6.8.0",
-				"babel-plugin-transform-flow-strip-types": "^6.8.0",
-				"babel-plugin-transform-object-rest-spread": "^6.8.0",
-				"babel-plugin-transform-react-display-name": "^6.8.0",
-				"babel-plugin-transform-react-jsx": "^6.8.0"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es3-member-expression-literals": "6.22.0",
+				"babel-plugin-transform-es3-property-literals": "6.22.0",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1"
 			}
 		},
 		"babel-preset-react-native": {
@@ -1493,37 +1493,37 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.0.tgz",
 			"integrity": "sha512-Wfbo6x244nUbBxjr7hQaNFdjj7FDYU+TVT7cFVPEdVPI68vhN52iLvamm+ErhNdHq6M4j1cMT6AJBYx7Wzdr0g==",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.5.0",
-				"babel-plugin-react-transform": "^3.0.0",
-				"babel-plugin-syntax-async-functions": "^6.5.0",
-				"babel-plugin-syntax-class-properties": "^6.5.0",
-				"babel-plugin-syntax-dynamic-import": "^6.18.0",
-				"babel-plugin-syntax-flow": "^6.5.0",
-				"babel-plugin-syntax-jsx": "^6.5.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.5.0",
-				"babel-plugin-transform-class-properties": "^6.5.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.5.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.5.0",
-				"babel-plugin-transform-es2015-classes": "^6.5.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.5.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.5.0",
-				"babel-plugin-transform-es2015-for-of": "^6.5.0",
-				"babel-plugin-transform-es2015-function-name": "^6.5.0",
-				"babel-plugin-transform-es2015-literals": "^6.5.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.5.0",
-				"babel-plugin-transform-es2015-parameters": "^6.5.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.5.0",
-				"babel-plugin-transform-es2015-spread": "^6.5.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.5.0",
-				"babel-plugin-transform-flow-strip-types": "^6.5.0",
-				"babel-plugin-transform-object-assign": "^6.5.0",
-				"babel-plugin-transform-object-rest-spread": "^6.5.0",
-				"babel-plugin-transform-react-display-name": "^6.5.0",
-				"babel-plugin-transform-react-jsx": "^6.5.0",
-				"babel-plugin-transform-react-jsx-source": "^6.5.0",
-				"babel-plugin-transform-regenerator": "^6.5.0",
-				"babel-template": "^6.24.1",
-				"react-transform-hmr": "^1.0.4"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-react-transform": "3.0.0",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-plugin-syntax-dynamic-import": "6.18.0",
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-plugin-transform-object-assign": "6.22.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-plugin-transform-regenerator": "6.26.0",
+				"babel-template": "6.26.0",
+				"react-transform-hmr": "1.0.4"
 			}
 		},
 		"babel-register": {
@@ -1531,13 +1531,13 @@
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.2",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.5",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1550,7 +1550,7 @@
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"requires": {
-						"source-map": "^0.5.6"
+						"source-map": "0.5.7"
 					}
 				}
 			}
@@ -1560,8 +1560,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1576,11 +1576,11 @@
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1588,15 +1588,15 @@
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-types": {
@@ -1604,10 +1604,10 @@
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -1625,13 +1625,13 @@
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1639,7 +1639,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1647,7 +1647,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1655,7 +1655,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1663,9 +1663,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -1700,7 +1700,7 @@
 			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
 			"integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
 			"requires": {
-				"stream-buffers": "~2.2.0"
+				"stream-buffers": "2.2.0"
 			}
 		},
 		"bplist-parser": {
@@ -1708,7 +1708,7 @@
 			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
 			"integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
 			"requires": {
-				"big-integer": "^1.6.7"
+				"big-integer": "1.6.28"
 			}
 		},
 		"brace-expansion": {
@@ -1716,7 +1716,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1725,16 +1725,16 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
+				"arr-flatten": "1.1.0",
+				"array-unique": "0.3.2",
+				"extend-shallow": "2.0.1",
+				"fill-range": "4.0.0",
+				"isobject": "3.0.1",
+				"repeat-element": "1.1.2",
+				"snapdragon": "0.8.2",
+				"snapdragon-node": "2.1.1",
+				"split-string": "3.1.0",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -1742,7 +1742,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -1752,7 +1752,7 @@
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer-from": {
@@ -1775,15 +1775,15 @@
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			}
 		},
 		"chalk": {
@@ -1791,11 +1791,11 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
 			}
 		},
 		"chardet": {
@@ -1808,10 +1808,10 @@
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1819,7 +1819,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -1829,7 +1829,7 @@
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-width": {
@@ -1842,8 +1842,8 @@
 			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
 			"integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
 			"requires": {
-				"arch": "^2.1.0",
-				"execa": "^0.8.0"
+				"arch": "2.1.0",
+				"execa": "0.8.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -1851,13 +1851,13 @@
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				}
 			}
@@ -1872,8 +1872,8 @@
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color-convert": {
@@ -1881,7 +1881,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -1914,7 +1914,7 @@
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
 			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
 			"requires": {
-				"mime-db": ">= 1.33.0 < 2"
+				"mime-db": "1.33.0"
 			}
 		},
 		"compression": {
@@ -1922,13 +1922,13 @@
 			"resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
 			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
 			"requires": {
-				"accepts": "~1.3.4",
+				"accepts": "1.3.5",
 				"bytes": "3.0.0",
-				"compressible": "~2.0.13",
+				"compressible": "2.0.13",
 				"debug": "2.6.9",
-				"on-headers": "~1.0.1",
+				"on-headers": "1.0.1",
 				"safe-buffer": "5.1.1",
-				"vary": "~1.1.2"
+				"vary": "1.1.2"
 			},
 			"dependencies": {
 				"safe-buffer": {
@@ -1948,10 +1948,10 @@
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"buffer-from": "1.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"typedarray": "0.0.6"
 			}
 		},
 		"connect": {
@@ -1961,7 +1961,7 @@
 			"requires": {
 				"debug": "2.6.9",
 				"finalhandler": "1.1.0",
-				"parseurl": "~1.3.2",
+				"parseurl": "1.3.2",
 				"utils-merge": "1.0.1"
 			}
 		},
@@ -1990,9 +1990,9 @@
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
 			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
 			"requires": {
-				"fbjs": "^0.8.9",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
 			}
 		},
 		"cross-spawn": {
@@ -2000,9 +2000,9 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.2",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
 			}
 		},
 		"debug": {
@@ -2028,8 +2028,8 @@
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -2037,7 +2037,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2045,7 +2045,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2053,9 +2053,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -2085,7 +2085,7 @@
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-newline": {
@@ -2113,7 +2113,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "0.4.19"
 			}
 		},
 		"envinfo": {
@@ -2121,11 +2121,11 @@
 			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.11.1.tgz",
 			"integrity": "sha512-hKkh7aKtont6Zuv4RmE4VkOc96TkBj9NXj7Ghsd/qCA9LuJI0Dh+ImwA1N5iORB9Vg+sz5bq9CHJzs51BILNCQ==",
 			"requires": {
-				"clipboardy": "^1.2.2",
-				"glob": "^7.1.2",
-				"minimist": "^1.2.0",
-				"os-name": "^2.0.1",
-				"which": "^1.2.14"
+				"clipboardy": "1.2.3",
+				"glob": "7.1.2",
+				"minimist": "1.2.0",
+				"os-name": "2.0.1",
+				"which": "1.3.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -2140,7 +2140,7 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"errorhandler": {
@@ -2148,8 +2148,8 @@
 			"resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.0.tgz",
 			"integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
 			"requires": {
-				"accepts": "~1.3.3",
-				"escape-html": "~1.0.3"
+				"accepts": "1.3.5",
+				"escape-html": "1.0.3"
 			}
 		},
 		"escape-html": {
@@ -2167,7 +2167,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-3.2.1.tgz",
 			"integrity": "sha512-1AnJO3JUCAoLpyOEsWCwN9hPJ0aQ72OT+JvLMuHjEWYb6QWxiNOszp24CEwegMzbREtJKI9OoRqYYDYxMxmjgQ==",
 			"requires": {
-				"eslint-plugin-react-native-globals": "^0.1.1"
+				"eslint-plugin-react-native-globals": "0.1.2"
 			}
 		},
 		"eslint-plugin-react-native-globals": {
@@ -2200,7 +2200,7 @@
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"requires": {
-				"merge": "^1.1.3"
+				"merge": "1.2.0"
 			}
 		},
 		"execa": {
@@ -2208,13 +2208,13 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"expand-brackets": {
@@ -2222,13 +2222,13 @@
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"posix-character-classes": "0.1.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2236,7 +2236,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -2244,7 +2244,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2254,7 +2254,7 @@
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.3"
 			},
 			"dependencies": {
 				"fill-range": {
@@ -2262,11 +2262,11 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^1.1.3",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
 					}
 				},
 				"is-number": {
@@ -2274,7 +2274,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"isarray": {
@@ -2295,7 +2295,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -2305,8 +2305,8 @@
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -2314,7 +2314,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -2324,9 +2324,9 @@
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -2334,14 +2334,14 @@
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"expand-brackets": "2.1.4",
+				"extend-shallow": "2.0.1",
+				"fragment-cache": "0.2.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2349,7 +2349,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -2357,7 +2357,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2365,7 +2365,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2373,7 +2373,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2381,9 +2381,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -2393,9 +2393,9 @@
 			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
 			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
 			"requires": {
-				"ansi-gray": "^0.1.1",
-				"color-support": "^1.1.3",
-				"time-stamp": "^1.0.0"
+				"ansi-gray": "0.1.1",
+				"color-support": "1.1.3",
+				"time-stamp": "1.1.0"
 			}
 		},
 		"fb-watchman": {
@@ -2403,7 +2403,7 @@
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.0.0"
 			}
 		},
 		"fbjs": {
@@ -2411,13 +2411,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.9"
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
 			}
 		},
 		"fbjs-scripts": {
@@ -2425,16 +2425,16 @@
 			"resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.8.3.tgz",
 			"integrity": "sha512-aUJ/uEzMIiBYuj/blLp4sVNkQQ7ZEB/lyplG1IzzOmZ83meiWecrGg5jBo4wWrxXmO4RExdtsSV1QkTjPt2Gag==",
 			"requires": {
-				"ansi-colors": "^1.0.1",
-				"babel-core": "^6.7.2",
-				"babel-preset-fbjs": "^2.1.2",
-				"core-js": "^2.4.1",
-				"cross-spawn": "^5.1.0",
-				"fancy-log": "^1.3.2",
-				"object-assign": "^4.0.1",
-				"plugin-error": "^0.1.2",
-				"semver": "^5.1.0",
-				"through2": "^2.0.0"
+				"ansi-colors": "1.1.0",
+				"babel-core": "6.26.2",
+				"babel-preset-fbjs": "2.1.4",
+				"core-js": "2.5.5",
+				"cross-spawn": "5.1.0",
+				"fancy-log": "1.3.2",
+				"object-assign": "4.1.1",
+				"plugin-error": "0.1.2",
+				"semver": "5.5.0",
+				"through2": "2.0.3"
 			},
 			"dependencies": {
 				"core-js": {
@@ -2449,7 +2449,7 @@
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"filename-regex": {
@@ -2462,10 +2462,10 @@
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
+				"extend-shallow": "2.0.1",
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1",
+				"to-regex-range": "2.1.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -2473,7 +2473,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2484,12 +2484,12 @@
 			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
 			"requires": {
 				"debug": "2.6.9",
-				"encodeurl": "~1.0.1",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.3.1",
-				"unpipe": "~1.0.0"
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.3.1",
+				"unpipe": "1.0.0"
 			}
 		},
 		"find-cache-dir": {
@@ -2497,9 +2497,9 @@
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"commondir": "1.0.1",
+				"make-dir": "1.2.0",
+				"pkg-dir": "2.0.0"
 			}
 		},
 		"find-up": {
@@ -2507,7 +2507,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"for-in": {
@@ -2520,7 +2520,7 @@
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"fragment-cache": {
@@ -2528,7 +2528,7 @@
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"fresh": {
@@ -2541,9 +2541,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
 			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^2.1.0",
-				"klaw": "^1.0.0"
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0",
+				"klaw": "1.3.1"
 			}
 		},
 		"fs.realpath": {
@@ -2557,8 +2557,8 @@
 			"integrity": "sha512-iownA+hC4uHFp+7gwP/y5SzaiUo7m2vpa0dhpzw8YuKtiZsz7cIXsFbXpLEeBM6WuCQyw1MH4RRe6XI8GFUctQ==",
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.9.0"
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.9.1"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2580,8 +2580,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
@@ -2592,7 +2592,7 @@
 					"version": "1.1.11",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -2646,7 +2646,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -2659,14 +2659,14 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -2674,12 +2674,12 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -2692,7 +2692,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -2700,7 +2700,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -2708,8 +2708,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -2725,7 +2725,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -2737,7 +2737,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -2748,8 +2748,8 @@
 					"version": "2.2.4",
 					"bundled": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -2757,7 +2757,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
@@ -2777,9 +2777,9 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -2787,16 +2787,16 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.6",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -2804,8 +2804,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -2818,8 +2818,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -2827,10 +2827,10 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2846,7 +2846,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2864,8 +2864,8 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -2883,10 +2883,10 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.4.2",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2901,13 +2901,13 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -2915,7 +2915,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -2951,9 +2951,9 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -2961,14 +2961,14 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -2981,13 +2981,13 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -3000,7 +3000,7 @@
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -3018,11 +3018,11 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
 			"integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
 			"requires": {
-				"ansi": "^0.3.0",
-				"has-unicode": "^2.0.0",
-				"lodash.pad": "^4.1.0",
-				"lodash.padend": "^4.1.0",
-				"lodash.padstart": "^4.1.0"
+				"ansi": "0.3.1",
+				"has-unicode": "2.0.1",
+				"lodash.pad": "4.5.1",
+				"lodash.padend": "4.6.1",
+				"lodash.padstart": "4.6.1"
 			}
 		},
 		"get-caller-file": {
@@ -3045,12 +3045,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -3058,8 +3058,8 @@
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -3067,7 +3067,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"global": {
@@ -3075,8 +3075,8 @@
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
 			"requires": {
-				"min-document": "^2.19.0",
-				"process": "~0.5.1"
+				"min-document": "2.19.0",
+				"process": "0.5.2"
 			}
 		},
 		"globals": {
@@ -3099,7 +3099,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-flag": {
@@ -3117,9 +3117,9 @@
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			}
 		},
 		"has-values": {
@@ -3127,8 +3127,8 @@
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3136,7 +3136,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3146,8 +3146,8 @@
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -3160,10 +3160,10 @@
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
-				"depd": "~1.1.2",
+				"depd": "1.1.2",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"statuses": "1.5.0"
 			},
 			"dependencies": {
 				"statuses": {
@@ -3193,8 +3193,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -3207,20 +3207,20 @@
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.4",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3233,7 +3233,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -3241,9 +3241,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"strip-ansi": {
@@ -3251,7 +3251,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -3259,7 +3259,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -3269,7 +3269,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"invert-kv": {
@@ -3282,7 +3282,7 @@
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3290,7 +3290,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3310,7 +3310,7 @@
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-data-descriptor": {
@@ -3318,7 +3318,7 @@
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3326,7 +3326,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3336,9 +3336,9 @@
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3358,7 +3358,7 @@
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -3376,7 +3376,7 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -3389,7 +3389,7 @@
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-number": {
@@ -3397,7 +3397,7 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3405,7 +3405,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3415,7 +3415,7 @@
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"requires": {
-				"is-number": "^4.0.0"
+				"is-number": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -3430,7 +3430,7 @@
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -3473,8 +3473,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
 			}
 		},
 		"jest-serializer": {
@@ -3497,7 +3497,7 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"requires": {
-				"jsonify": "~0.0.0"
+				"jsonify": "0.0.0"
 			}
 		},
 		"json5": {
@@ -3510,7 +3510,7 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "4.1.11"
 			}
 		},
 		"jsonify": {
@@ -3528,7 +3528,7 @@
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
 			"requires": {
-				"graceful-fs": "^4.1.9"
+				"graceful-fs": "4.1.11"
 			}
 		},
 		"lcid": {
@@ -3536,7 +3536,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"left-pad": {
@@ -3549,8 +3549,8 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -3583,7 +3583,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -3591,8 +3591,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"macos-release": {
@@ -3605,7 +3605,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -3620,7 +3620,7 @@
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -3633,7 +3633,7 @@
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"mem": {
@@ -3641,7 +3641,7 @@
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"merge": {
@@ -3654,7 +3654,7 @@
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"metro": {
@@ -3662,69 +3662,69 @@
 			"resolved": "https://registry.npmjs.org/metro/-/metro-0.30.2.tgz",
 			"integrity": "sha512-wmdkh4AsfZjWaMM++KMDswQHdyo5L9a0XAaQBL4XTJdQIRG+x+Rmjixe7tDki5jKwe9XxsjjbpbdYKswOANuiw==",
 			"requires": {
-				"@babel/core": "^7.0.0-beta",
-				"@babel/generator": "^7.0.0-beta",
-				"@babel/helper-remap-async-to-generator": "^7.0.0-beta",
-				"@babel/plugin-external-helpers": "^7.0.0-beta",
-				"@babel/plugin-proposal-class-properties": "^7.0.0-beta",
-				"@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta",
-				"@babel/plugin-syntax-dynamic-import": "^7.0.0-beta",
-				"@babel/plugin-transform-arrow-functions": "^7.0.0-beta",
-				"@babel/plugin-transform-block-scoping": "^7.0.0-beta",
-				"@babel/plugin-transform-classes": "^7.0.0-beta",
-				"@babel/plugin-transform-computed-properties": "^7.0.0-beta",
-				"@babel/plugin-transform-destructuring": "^7.0.0-beta",
-				"@babel/plugin-transform-exponentiation-operator": "^7.0.0-beta",
-				"@babel/plugin-transform-flow-strip-types": "^7.0.0-beta",
-				"@babel/plugin-transform-for-of": "^7.0.0-beta",
-				"@babel/plugin-transform-function-name": "^7.0.0-beta",
-				"@babel/plugin-transform-literals": "^7.0.0-beta",
-				"@babel/plugin-transform-modules-commonjs": "^7.0.0-beta",
-				"@babel/plugin-transform-object-assign": "^7.0.0-beta",
-				"@babel/plugin-transform-parameters": "^7.0.0-beta",
-				"@babel/plugin-transform-react-display-name": "^7.0.0-beta",
-				"@babel/plugin-transform-react-jsx": "^7.0.0-beta",
-				"@babel/plugin-transform-react-jsx-source": "^7.0.0-beta",
-				"@babel/plugin-transform-regenerator": "^7.0.0-beta",
-				"@babel/plugin-transform-shorthand-properties": "^7.0.0-beta",
-				"@babel/plugin-transform-spread": "^7.0.0-beta",
-				"@babel/plugin-transform-template-literals": "^7.0.0-beta",
-				"@babel/register": "^7.0.0-beta",
-				"@babel/template": "^7.0.0-beta",
-				"@babel/traverse": "^7.0.0-beta",
-				"@babel/types": "^7.0.0-beta",
-				"absolute-path": "^0.0.0",
-				"async": "^2.4.0",
-				"babel-core": "^6.24.1",
-				"babel-generator": "^6.26.0",
-				"babel-plugin-external-helpers": "^6.22.0",
-				"babel-plugin-react-transform": "^3.0.0",
-				"babel-plugin-transform-flow-strip-types": "^6.21.0",
-				"babel-preset-es2015-node": "^6.1.1",
-				"babel-preset-fbjs": "^2.1.4",
-				"babel-preset-react-native": "^4.0.0",
-				"babel-register": "^6.24.1",
-				"babel-template": "^6.24.1",
-				"babylon": "^6.18.0",
-				"chalk": "^1.1.1",
-				"concat-stream": "^1.6.0",
-				"connect": "^3.6.5",
-				"core-js": "^2.2.2",
-				"debug": "^2.2.0",
-				"denodeify": "^1.2.1",
-				"eventemitter3": "^3.0.0",
-				"fbjs": "^0.8.14",
-				"fs-extra": "^1.0.0",
-				"graceful-fs": "^4.1.3",
-				"image-size": "^0.6.0",
+				"@babel/core": "7.0.0-beta.46",
+				"@babel/generator": "7.0.0-beta.46",
+				"@babel/helper-remap-async-to-generator": "7.0.0-beta.46",
+				"@babel/plugin-external-helpers": "7.0.0-beta.46",
+				"@babel/plugin-proposal-class-properties": "7.0.0-beta.46",
+				"@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.46",
+				"@babel/plugin-syntax-dynamic-import": "7.0.0-beta.46",
+				"@babel/plugin-transform-arrow-functions": "7.0.0-beta.46",
+				"@babel/plugin-transform-block-scoping": "7.0.0-beta.46",
+				"@babel/plugin-transform-classes": "7.0.0-beta.46",
+				"@babel/plugin-transform-computed-properties": "7.0.0-beta.46",
+				"@babel/plugin-transform-destructuring": "7.0.0-beta.46",
+				"@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.46",
+				"@babel/plugin-transform-flow-strip-types": "7.0.0-beta.46",
+				"@babel/plugin-transform-for-of": "7.0.0-beta.46",
+				"@babel/plugin-transform-function-name": "7.0.0-beta.46",
+				"@babel/plugin-transform-literals": "7.0.0-beta.46",
+				"@babel/plugin-transform-modules-commonjs": "7.0.0-beta.46",
+				"@babel/plugin-transform-object-assign": "7.0.0-beta.46",
+				"@babel/plugin-transform-parameters": "7.0.0-beta.46",
+				"@babel/plugin-transform-react-display-name": "7.0.0-beta.46",
+				"@babel/plugin-transform-react-jsx": "7.0.0-beta.46",
+				"@babel/plugin-transform-react-jsx-source": "7.0.0-beta.46",
+				"@babel/plugin-transform-regenerator": "7.0.0-beta.46",
+				"@babel/plugin-transform-shorthand-properties": "7.0.0-beta.46",
+				"@babel/plugin-transform-spread": "7.0.0-beta.46",
+				"@babel/plugin-transform-template-literals": "7.0.0-beta.46",
+				"@babel/register": "7.0.0-beta.46",
+				"@babel/template": "7.0.0-beta.46",
+				"@babel/traverse": "7.0.0-beta.46",
+				"@babel/types": "7.0.0-beta.46",
+				"absolute-path": "0.0.0",
+				"async": "2.6.0",
+				"babel-core": "6.26.2",
+				"babel-generator": "6.26.1",
+				"babel-plugin-external-helpers": "6.22.0",
+				"babel-plugin-react-transform": "3.0.0",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-preset-es2015-node": "6.1.1",
+				"babel-preset-fbjs": "2.1.4",
+				"babel-preset-react-native": "4.0.0",
+				"babel-register": "6.26.0",
+				"babel-template": "6.26.0",
+				"babylon": "6.18.0",
+				"chalk": "1.1.3",
+				"concat-stream": "1.6.2",
+				"connect": "3.6.6",
+				"core-js": "2.5.5",
+				"debug": "2.6.9",
+				"denodeify": "1.2.1",
+				"eventemitter3": "3.1.0",
+				"fbjs": "0.8.16",
+				"fs-extra": "1.0.0",
+				"graceful-fs": "4.1.11",
+				"image-size": "0.6.2",
 				"jest-docblock": "22.4.0",
 				"jest-haste-map": "22.4.2",
 				"jest-worker": "22.2.2",
-				"json-stable-stringify": "^1.0.1",
-				"json5": "^0.4.0",
-				"left-pad": "^1.1.3",
-				"lodash.throttle": "^4.1.1",
-				"merge-stream": "^1.0.1",
+				"json-stable-stringify": "1.0.1",
+				"json5": "0.4.0",
+				"left-pad": "1.3.0",
+				"lodash.throttle": "4.1.1",
+				"merge-stream": "1.0.1",
 				"metro-babylon7": "0.30.2",
 				"metro-cache": "0.30.2",
 				"metro-core": "0.30.2",
@@ -3732,19 +3732,19 @@
 				"metro-resolver": "0.30.2",
 				"metro-source-map": "0.30.2",
 				"mime-types": "2.1.11",
-				"mkdirp": "^0.5.1",
-				"node-fetch": "^1.3.3",
-				"resolve": "^1.5.0",
-				"rimraf": "^2.5.4",
-				"serialize-error": "^2.1.0",
-				"source-map": "^0.5.6",
+				"mkdirp": "0.5.1",
+				"node-fetch": "1.7.3",
+				"resolve": "1.7.1",
+				"rimraf": "2.6.2",
+				"serialize-error": "2.1.0",
+				"source-map": "0.5.7",
 				"temp": "0.8.3",
-				"throat": "^4.1.0",
-				"wordwrap": "^1.0.0",
-				"write-file-atomic": "^1.2.0",
-				"ws": "^1.1.0",
-				"xpipe": "^1.0.5",
-				"yargs": "^9.0.0"
+				"throat": "4.1.0",
+				"wordwrap": "1.0.0",
+				"write-file-atomic": "1.3.4",
+				"ws": "1.1.5",
+				"xpipe": "1.0.5",
+				"yargs": "9.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -3752,7 +3752,7 @@
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -3765,9 +3765,9 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"camelcase": {
@@ -3780,9 +3780,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -3790,9 +3790,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -3807,7 +3807,7 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -3815,7 +3815,7 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -3823,7 +3823,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"jest-docblock": {
@@ -3831,7 +3831,7 @@
 					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
 					"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
 					"requires": {
-						"detect-newline": "^2.1.0"
+						"detect-newline": "2.1.0"
 					}
 				},
 				"jest-haste-map": {
@@ -3839,13 +3839,13 @@
 					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
 					"integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
 					"requires": {
-						"fb-watchman": "^2.0.0",
-						"graceful-fs": "^4.1.11",
-						"jest-docblock": "^22.4.0",
-						"jest-serializer": "^22.4.0",
-						"jest-worker": "^22.2.2",
-						"micromatch": "^2.3.11",
-						"sane": "^2.0.0"
+						"fb-watchman": "2.0.0",
+						"graceful-fs": "4.1.11",
+						"jest-docblock": "22.4.0",
+						"jest-serializer": "22.4.3",
+						"jest-worker": "22.2.2",
+						"micromatch": "2.3.11",
+						"sane": "2.5.0"
 					}
 				},
 				"jest-worker": {
@@ -3853,7 +3853,7 @@
 					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
 					"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
 					"requires": {
-						"merge-stream": "^1.0.1"
+						"merge-stream": "1.0.1"
 					}
 				},
 				"json5": {
@@ -3866,7 +3866,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"load-json-file": {
@@ -3874,10 +3874,10 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"micromatch": {
@@ -3885,19 +3885,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"mime-db": {
@@ -3910,7 +3910,7 @@
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
 					"integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
 					"requires": {
-						"mime-db": "~1.23.0"
+						"mime-db": "1.23.0"
 					}
 				},
 				"path-type": {
@@ -3918,7 +3918,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"requires": {
-						"pify": "^2.0.0"
+						"pify": "2.3.0"
 					}
 				},
 				"read-pkg": {
@@ -3926,9 +3926,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -3936,8 +3936,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					}
 				},
 				"resolve": {
@@ -3945,7 +3945,7 @@
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 					"requires": {
-						"path-parse": "^1.0.5"
+						"path-parse": "1.0.5"
 					}
 				},
 				"strip-bom": {
@@ -3963,9 +3963,9 @@
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
 					}
 				},
 				"ws": {
@@ -3973,8 +3973,8 @@
 					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
 					"integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
 					"requires": {
-						"options": ">=0.0.5",
-						"ultron": "1.0.x"
+						"options": "0.0.6",
+						"ultron": "1.0.2"
 					}
 				},
 				"yargs": {
@@ -3982,19 +3982,19 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
 					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
 					"requires": {
-						"camelcase": "^4.1.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"read-pkg-up": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^7.0.0"
+						"camelcase": "4.1.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "7.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -4002,7 +4002,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -4012,7 +4012,7 @@
 			"resolved": "https://registry.npmjs.org/metro-babylon7/-/metro-babylon7-0.30.2.tgz",
 			"integrity": "sha512-ZI0h4/3raGnzA6fFXwLUMidGOG4jkDi9fgFkoI8I4Ack3TDMabmZATu9RD6DaSolu3lylhfPd8DeAAMeopX9CA==",
 			"requires": {
-				"babylon": "^7.0.0-beta"
+				"babylon": "7.0.0-beta.46"
 			},
 			"dependencies": {
 				"babylon": {
@@ -4027,8 +4027,8 @@
 			"resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.30.2.tgz",
 			"integrity": "sha512-XYd07OwgtZRHFXyip40wdNJ8abPJRziuE5bb3jjf8wvyHxCpzlZlvbe0ZhcR8ChBwFUjHMuVyoou52AC3a0f+g==",
 			"requires": {
-				"jest-serializer": "^22.4.0",
-				"mkdirp": "^0.5.1"
+				"jest-serializer": "22.4.3",
+				"mkdirp": "0.5.1"
 			}
 		},
 		"metro-core": {
@@ -4036,8 +4036,8 @@
 			"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.30.2.tgz",
 			"integrity": "sha512-2Y89PpD9sE/8QaHhYxaI21WFxkVmjbxdphiOPdsC9t7A3kQHMYOTQPYFon3bkYM7tL8k9YVBimXSv20JGglqUA==",
 			"requires": {
-				"lodash.throttle": "^4.1.1",
-				"wordwrap": "^1.0.0"
+				"lodash.throttle": "4.1.1",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -4052,7 +4052,7 @@
 			"resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.30.2.tgz",
 			"integrity": "sha512-xwqMqYYKZEqJ66Wpf5OpyPJhApOQDb8rYiO94VInlDeHpN7eKGCVILclnx9AmVM3dStmebvXa5jrdgsbnJ1bSg==",
 			"requires": {
-				"uglify-es": "^3.1.9"
+				"uglify-es": "3.3.9"
 			},
 			"dependencies": {
 				"commander": {
@@ -4070,8 +4070,8 @@
 					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
+						"commander": "2.13.0",
+						"source-map": "0.6.1"
 					}
 				}
 			}
@@ -4081,7 +4081,7 @@
 			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.30.2.tgz",
 			"integrity": "sha512-bODCys/WYpqJ+KYbCIENZu1eqdQu3g/d2fXfhAROhutqojMqrT1eIGhzWpk3G1k/J6vlaf69uW6xrVuheg0ktg==",
 			"requires": {
-				"absolute-path": "^0.0.0"
+				"absolute-path": "0.0.0"
 			}
 		},
 		"metro-source-map": {
@@ -4089,7 +4089,7 @@
 			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.30.2.tgz",
 			"integrity": "sha512-9tW3B1JOdXhyDJnR4wOPOsOlYWSL+xh6J+N5/DADGEK/X/+Up/lEHdEfpB+/+yGk1LHaRHcKCahtLPNl/to7Sg==",
 			"requires": {
-				"source-map": "^0.5.6"
+				"source-map": "0.5.7"
 			}
 		},
 		"micromatch": {
@@ -4097,19 +4097,19 @@
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"braces": "2.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"extglob": "2.0.4",
+				"fragment-cache": "0.2.1",
+				"kind-of": "6.0.2",
+				"nanomatch": "1.2.9",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"mime": {
@@ -4127,7 +4127,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "~1.33.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -4140,7 +4140,7 @@
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
 			"requires": {
-				"dom-walk": "^0.1.0"
+				"dom-walk": "0.1.1"
 			}
 		},
 		"minimatch": {
@@ -4148,7 +4148,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -4161,8 +4161,8 @@
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -4170,7 +4170,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -4188,11 +4188,11 @@
 			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
 			"integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
 			"requires": {
-				"basic-auth": "~2.0.0",
+				"basic-auth": "2.0.0",
 				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.1"
+				"depd": "1.1.2",
+				"on-finished": "2.3.0",
+				"on-headers": "1.0.1"
 			}
 		},
 		"ms": {
@@ -4216,18 +4216,18 @@
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"negotiator": {
@@ -4240,8 +4240,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
 			}
 		},
 		"node-int64": {
@@ -4259,10 +4259,10 @@
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"requires": {
-				"growly": "^1.3.0",
-				"semver": "^5.4.1",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
 			}
 		},
 		"normalize-package-data": {
@@ -4270,10 +4270,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"normalize-path": {
@@ -4281,7 +4281,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"npm-run-path": {
@@ -4289,7 +4289,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"npmlog": {
@@ -4297,9 +4297,9 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
 			"integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
 			"requires": {
-				"ansi": "~0.3.1",
-				"are-we-there-yet": "~1.1.2",
-				"gauge": "~1.2.5"
+				"ansi": "0.3.1",
+				"are-we-there-yet": "1.1.4",
+				"gauge": "1.2.7"
 			}
 		},
 		"number-is-nan": {
@@ -4317,9 +4317,9 @@
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -4327,7 +4327,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"kind-of": {
@@ -4335,7 +4335,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4345,7 +4345,7 @@
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.omit": {
@@ -4353,8 +4353,8 @@
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -4362,7 +4362,7 @@
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"on-finished": {
@@ -4383,7 +4383,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -4391,7 +4391,7 @@
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"opn": {
@@ -4399,7 +4399,7 @@
 			"resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
 			"integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
 			"requires": {
-				"object-assign": "^4.0.1"
+				"object-assign": "4.1.1"
 			}
 		},
 		"optimist": {
@@ -4407,8 +4407,8 @@
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
 			}
 		},
 		"options": {
@@ -4426,9 +4426,9 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-name": {
@@ -4436,8 +4436,8 @@
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
 			"integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
 			"requires": {
-				"macos-release": "^1.0.0",
-				"win-release": "^1.0.0"
+				"macos-release": "1.1.0",
+				"win-release": "1.1.1"
 			}
 		},
 		"os-tmpdir": {
@@ -4455,7 +4455,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -4463,7 +4463,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.2.0"
 			}
 		},
 		"p-try": {
@@ -4476,10 +4476,10 @@
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -4487,7 +4487,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.1"
 			}
 		},
 		"parseurl": {
@@ -4535,7 +4535,7 @@
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
 			"integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
 			"requires": {
-				"node-modules-regexp": "^1.0.0"
+				"node-modules-regexp": "1.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -4543,7 +4543,7 @@
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"plist": {
@@ -4554,7 +4554,7 @@
 				"base64-js": "0.0.8",
 				"util-deprecate": "1.0.2",
 				"xmlbuilder": "4.0.0",
-				"xmldom": "0.1.x"
+				"xmldom": "0.1.27"
 			},
 			"dependencies": {
 				"base64-js": {
@@ -4569,11 +4569,11 @@
 			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
 			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
 			"requires": {
-				"ansi-cyan": "^0.1.1",
-				"ansi-red": "^0.1.1",
-				"arr-diff": "^1.0.1",
-				"arr-union": "^2.0.1",
-				"extend-shallow": "^1.1.2"
+				"ansi-cyan": "0.1.1",
+				"ansi-red": "0.1.1",
+				"arr-diff": "1.1.0",
+				"arr-union": "2.1.0",
+				"extend-shallow": "1.1.4"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -4581,8 +4581,8 @@
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
 					"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
 					"requires": {
-						"arr-flatten": "^1.0.1",
-						"array-slice": "^0.2.3"
+						"arr-flatten": "1.1.0",
+						"array-slice": "0.2.3"
 					}
 				},
 				"arr-union": {
@@ -4595,7 +4595,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
 					"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
 					"requires": {
-						"kind-of": "^1.1.0"
+						"kind-of": "1.1.0"
 					}
 				},
 				"kind-of": {
@@ -4635,7 +4635,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "~2.0.3"
+				"asap": "2.0.6"
 			}
 		},
 		"prop-types": {
@@ -4643,9 +4643,9 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
 			}
 		},
 		"pseudomap": {
@@ -4658,8 +4658,8 @@
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4667,7 +4667,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4682,10 +4682,10 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
 			"integrity": "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-clone-referenced-element": {
@@ -4703,8 +4703,8 @@
 			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.1.0.tgz",
 			"integrity": "sha512-fO6SmpW16E9u6Lb6zQOHrjhJXGBNz+cJ0/a9cSF55nXfL0sQLlvYJR8DpU7f4rMUrVnVineg4XQyYYBZicmhJg==",
 			"requires": {
-				"shell-quote": "^1.6.1",
-				"ws": "^2.0.3"
+				"shell-quote": "1.6.1",
+				"ws": "2.3.1"
 			},
 			"dependencies": {
 				"safe-buffer": {
@@ -4722,8 +4722,8 @@
 					"resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
 					"integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
 					"requires": {
-						"safe-buffer": "~5.0.1",
-						"ultron": "~1.1.0"
+						"safe-buffer": "5.0.1",
+						"ultron": "1.1.1"
 					}
 				}
 			}
@@ -4738,65 +4738,65 @@
 			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.55.3.tgz",
 			"integrity": "sha512-9zdBao5Pv2CzhtUVFiDnXzxjokRtXTHxmAh+DRbNqUZHkBn5PUm9lOembwj+VZFvZchXNLqa3S2MOYGushHTbA==",
 			"requires": {
-				"absolute-path": "^0.0.0",
-				"art": "^0.10.0",
-				"babel-core": "^6.24.1",
-				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
+				"absolute-path": "0.0.0",
+				"art": "0.10.2",
+				"babel-core": "6.26.2",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-to-generator": "6.16.0",
-				"babel-plugin-transform-class-properties": "^6.18.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.5.0",
-				"babel-plugin-transform-flow-strip-types": "^6.21.0",
-				"babel-plugin-transform-object-rest-spread": "^6.20.2",
-				"babel-register": "^6.24.1",
-				"babel-runtime": "^6.23.0",
-				"base64-js": "^1.1.2",
-				"chalk": "^1.1.1",
-				"commander": "^2.9.0",
-				"compression": "^1.7.1",
-				"connect": "^3.6.5",
-				"create-react-class": "^15.6.3",
-				"debug": "^2.2.0",
-				"denodeify": "^1.2.1",
-				"envinfo": "^3.0.0",
-				"errorhandler": "^1.5.0",
-				"eslint-plugin-react-native": "^3.2.1",
-				"event-target-shim": "^1.0.5",
-				"fbjs": "^0.8.14",
-				"fbjs-scripts": "^0.8.1",
-				"fs-extra": "^1.0.0",
-				"glob": "^7.1.1",
-				"graceful-fs": "^4.1.3",
-				"inquirer": "^3.0.6",
-				"lodash": "^4.17.5",
-				"metro": "^0.30.0",
-				"metro-core": "^0.30.0",
-				"mime": "^1.3.4",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"morgan": "^1.9.0",
-				"node-fetch": "^1.3.3",
-				"node-notifier": "^5.2.1",
-				"npmlog": "^2.0.4",
-				"opn": "^3.0.2",
-				"optimist": "^0.6.1",
-				"plist": "^1.2.0",
-				"pretty-format": "^4.2.1",
-				"promise": "^7.1.1",
-				"prop-types": "^15.5.8",
-				"react-clone-referenced-element": "^1.0.1",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"base64-js": "1.3.0",
+				"chalk": "1.1.3",
+				"commander": "2.15.1",
+				"compression": "1.7.2",
+				"connect": "3.6.6",
+				"create-react-class": "15.6.3",
+				"debug": "2.6.9",
+				"denodeify": "1.2.1",
+				"envinfo": "3.11.1",
+				"errorhandler": "1.5.0",
+				"eslint-plugin-react-native": "3.2.1",
+				"event-target-shim": "1.1.1",
+				"fbjs": "0.8.16",
+				"fbjs-scripts": "0.8.3",
+				"fs-extra": "1.0.0",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"inquirer": "3.3.0",
+				"lodash": "4.17.10",
+				"metro": "0.30.2",
+				"metro-core": "0.30.2",
+				"mime": "1.6.0",
+				"minimist": "1.2.0",
+				"mkdirp": "0.5.1",
+				"morgan": "1.9.0",
+				"node-fetch": "1.7.3",
+				"node-notifier": "5.2.1",
+				"npmlog": "2.0.4",
+				"opn": "3.0.3",
+				"optimist": "0.6.1",
+				"plist": "1.2.0",
+				"pretty-format": "4.3.1",
+				"promise": "7.3.1",
+				"prop-types": "15.6.1",
+				"react-clone-referenced-element": "1.0.1",
 				"react-devtools-core": "3.1.0",
-				"react-timer-mixin": "^0.13.2",
-				"regenerator-runtime": "^0.11.0",
-				"rimraf": "^2.5.4",
-				"semver": "^5.0.3",
-				"serve-static": "^1.13.1",
+				"react-timer-mixin": "0.13.3",
+				"regenerator-runtime": "0.11.1",
+				"rimraf": "2.6.2",
+				"semver": "5.5.0",
+				"serve-static": "1.13.2",
 				"shell-quote": "1.6.1",
-				"stacktrace-parser": "^0.1.3",
-				"whatwg-fetch": "^1.0.0",
-				"ws": "^1.1.0",
-				"xcode": "^0.9.1",
-				"xmldoc": "^0.4.0",
-				"yargs": "^9.0.0"
+				"stacktrace-parser": "0.1.4",
+				"whatwg-fetch": "1.1.1",
+				"ws": "1.1.5",
+				"xcode": "0.9.3",
+				"xmldoc": "0.4.0",
+				"yargs": "9.0.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -4809,9 +4809,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -4819,9 +4819,9 @@
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						}
 					}
@@ -4831,7 +4831,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"load-json-file": {
@@ -4839,10 +4839,10 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"lodash": {
@@ -4860,7 +4860,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"requires": {
-						"pify": "^2.0.0"
+						"pify": "2.3.0"
 					}
 				},
 				"pretty-format": {
@@ -4873,9 +4873,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -4883,8 +4883,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4902,8 +4902,8 @@
 					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
 					"integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
 					"requires": {
-						"options": ">=0.0.5",
-						"ultron": "1.0.x"
+						"options": "0.0.6",
+						"ultron": "1.0.2"
 					}
 				},
 				"yargs": {
@@ -4911,19 +4911,19 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
 					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
 					"requires": {
-						"camelcase": "^4.1.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"read-pkg-up": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^7.0.0"
+						"camelcase": "4.1.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "7.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -4931,7 +4931,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -4941,8 +4941,8 @@
 			"resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
 			"integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
 			"requires": {
-				"lodash": "^4.6.1",
-				"react-deep-force-update": "^1.0.0"
+				"lodash": "4.17.4",
+				"react-deep-force-update": "1.1.1"
 			}
 		},
 		"react-test-renderer": {
@@ -4950,10 +4950,10 @@
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.3.1.tgz",
 			"integrity": "sha512-emEcIPUowMjT5EQ+rrb0FAwVCzuJ+LKDweoYDh073v2/jHxrBDPUk8nzI5dofG3R+140+Bb9TMcT2Ez5OP6pQw==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0",
-				"react-is": "^16.3.1"
+				"fbjs": "0.8.16",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1",
+				"react-is": "16.3.2"
 			}
 		},
 		"react-timer-mixin": {
@@ -4966,8 +4966,8 @@
 			"resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
 			"integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
 			"requires": {
-				"global": "^4.3.0",
-				"react-proxy": "^1.1.7"
+				"global": "4.3.2",
+				"react-proxy": "1.1.8"
 			}
 		},
 		"readable-stream": {
@@ -4975,13 +4975,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			},
 			"dependencies": {
 				"isarray": {
@@ -5006,9 +5006,9 @@
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.8"
 			}
 		},
 		"regex-cache": {
@@ -5016,7 +5016,7 @@
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -5024,8 +5024,8 @@
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -5033,9 +5033,9 @@
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"regjsgen": {
@@ -5048,7 +5048,7 @@
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -5078,7 +5078,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"require-directory": {
@@ -5101,8 +5101,8 @@
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -5115,7 +5115,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"run-async": {
@@ -5123,7 +5123,7 @@
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -5136,7 +5136,7 @@
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"safe-buffer": {
@@ -5149,7 +5149,7 @@
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"sane": {
@@ -5157,14 +5157,14 @@
 			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
 			"integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
 			"requires": {
-				"anymatch": "^2.0.0",
-				"exec-sh": "^0.2.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.1.1",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"anymatch": "2.0.0",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.2",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -5185,18 +5185,18 @@
 			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
 			"requires": {
 				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
+				"http-errors": "1.6.3",
 				"mime": "1.4.1",
 				"ms": "2.0.0",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.4.0"
 			},
 			"dependencies": {
 				"mime": {
@@ -5221,9 +5221,9 @@
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
 				"send": "0.16.2"
 			}
 		},
@@ -5237,10 +5237,10 @@
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -5248,7 +5248,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -5268,7 +5268,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -5281,10 +5281,10 @@
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
 			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
 			"requires": {
-				"array-filter": "~0.0.0",
-				"array-map": "~0.0.0",
-				"array-reduce": "~0.0.0",
-				"jsonify": "~0.0.0"
+				"array-filter": "0.0.1",
+				"array-map": "0.0.0",
+				"array-reduce": "0.0.0",
+				"jsonify": "0.0.0"
 			}
 		},
 		"shellwords": {
@@ -5319,7 +5319,7 @@
 					"requires": {
 						"base64-js": "1.1.2",
 						"xmlbuilder": "8.2.2",
-						"xmldom": "0.1.x"
+						"xmldom": "0.1.27"
 					}
 				},
 				"xmlbuilder": {
@@ -5344,14 +5344,14 @@
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.1",
+				"use": "3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5359,7 +5359,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -5367,7 +5367,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -5377,9 +5377,9 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5387,7 +5387,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -5395,7 +5395,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -5403,7 +5403,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -5411,9 +5411,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -5423,7 +5423,7 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5431,7 +5431,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5446,11 +5446,11 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 			"requires": {
-				"atob": "^2.0.0",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.0",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-url": {
@@ -5463,8 +5463,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -5477,8 +5477,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -5491,7 +5491,7 @@
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"stacktrace-parser": {
@@ -5504,8 +5504,8 @@
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5513,7 +5513,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -5533,8 +5533,8 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -5547,7 +5547,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -5557,7 +5557,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"strip-ansi": {
@@ -5565,7 +5565,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-eof": {
@@ -5583,8 +5583,8 @@
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
 			"requires": {
-				"os-tmpdir": "^1.0.0",
-				"rimraf": "~2.2.6"
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
 			},
 			"dependencies": {
 				"rimraf": {
@@ -5609,8 +5609,8 @@
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"requires": {
-				"readable-stream": "^2.1.5",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.6",
+				"xtend": "4.0.1"
 			}
 		},
 		"time-stamp": {
@@ -5623,7 +5623,7 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"tmpl": {
@@ -5641,7 +5641,7 @@
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5649,7 +5649,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5659,10 +5659,10 @@
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -5670,8 +5670,8 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"trim-right": {
@@ -5699,10 +5699,10 @@
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -5710,7 +5710,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -5718,10 +5718,10 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -5736,8 +5736,8 @@
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -5745,9 +5745,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -5782,7 +5782,7 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"requires": {
-				"kind-of": "^6.0.2"
+				"kind-of": "6.0.2"
 			}
 		},
 		"util-deprecate": {
@@ -5800,8 +5800,8 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"vary": {
@@ -5814,7 +5814,7 @@
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"watch": {
@@ -5822,8 +5822,8 @@
 			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -5843,7 +5843,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -5856,7 +5856,7 @@
 			"resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
 			"integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
 			"requires": {
-				"semver": "^5.0.1"
+				"semver": "5.5.0"
 			}
 		},
 		"wordwrap": {
@@ -5869,8 +5869,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -5878,7 +5878,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -5886,9 +5886,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -5903,8 +5903,8 @@
 			"resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
 			"integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
 			"requires": {
-				"pegjs": "^0.10.0",
-				"simple-plist": "^0.2.1",
+				"pegjs": "0.10.0",
+				"simple-plist": "0.2.1",
 				"uuid": "3.0.1"
 			},
 			"dependencies": {
@@ -5920,7 +5920,7 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
 			"integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
 			"requires": {
-				"lodash": "^3.5.0"
+				"lodash": "3.10.1"
 			},
 			"dependencies": {
 				"lodash": {
@@ -5935,7 +5935,7 @@
 			"resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
 			"integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
 			"requires": {
-				"sax": "~1.1.1"
+				"sax": "1.1.6"
 			},
 			"dependencies": {
 				"sax": {

--- a/packages/react-router-redux/examples/AuthExample.js
+++ b/packages/react-router-redux/examples/AuthExample.js
@@ -1,114 +1,112 @@
-import React from 'react'
-import { render } from 'react-dom'
-import { connect, Provider } from 'react-redux'
+import React from "react";
+import { render } from "react-dom";
+import { connect, Provider } from "react-redux";
 import {
   ConnectedRouter,
   routerReducer,
   routerMiddleware,
   push
-} from 'react-router-redux'
+} from "react-router-redux";
 
-import { createStore, applyMiddleware, combineReducers } from 'redux'
-import createHistory from 'history/createBrowserHistory'
+import { createStore, applyMiddleware, combineReducers } from "redux";
+import createHistory from "history/createBrowserHistory";
 
-import { Route, Switch } from 'react-router'
-import { Redirect } from 'react-router-dom'
+import { Route, Switch } from "react-router";
+import { Redirect } from "react-router-dom";
 
-const history = createHistory()
+const history = createHistory();
 
 const authSuccess = () => ({
-  type: 'AUTH_SUCCESS'
-})
+  type: "AUTH_SUCCESS"
+});
 
 const authFail = () => ({
-  type: 'AUTH_FAIL'
-})
+  type: "AUTH_FAIL"
+});
 
 const initialState = {
   isAuthenticated: false
-}
+};
 
-const authReducer = (state = initialState , action) => {
+const authReducer = (state = initialState, action) => {
   switch (action.type) {
-    case 'AUTH_SUCCESS':
+    case "AUTH_SUCCESS":
       return {
         ...state,
         isAuthenticated: true
-      }
-    case 'AUTH_FAIL':
+      };
+    case "AUTH_FAIL":
       return {
         ...state,
         isAuthenticated: false
-      }
+      };
     default:
-      return state
+      return state;
   }
-}
+};
 
 const store = createStore(
   combineReducers({ routerReducer, authReducer }),
-  applyMiddleware(routerMiddleware(history)),
-)
+  applyMiddleware(routerMiddleware(history))
+);
 
 class LoginContainer extends React.Component {
   render() {
-    return <button onClick={this.props.login}>Login Here!</button>
+    return <button onClick={this.props.login}>Login Here!</button>;
   }
 }
 
 class HomeContainer extends React.Component {
-  componentWillMount() {
-    alert('Private home is at: ' + this.props.location.pathname)
+  componentDidMount() {
+    alert("Private home is at: " + this.props.location.pathname);
   }
 
   render() {
-    return <button onClick={this.props.logout}>Logout Here!</button>
+    return <button onClick={this.props.logout}>Logout Here!</button>;
   }
 }
 
 class PrivateRouteContainer extends React.Component {
   render() {
-    const {
-      isAuthenticated,
-      component: Component,
-      ...props
-    } = this.props
+    const { isAuthenticated, component: Component, ...props } = this.props;
 
     return (
       <Route
         {...props}
         render={props =>
-          isAuthenticated
-            ? <Component {...props} />
-            : (
-            <Redirect to={{
-              pathname: '/login',
-              state: { from: props.location }
-            }} />
+          isAuthenticated ? (
+            <Component {...props} />
+          ) : (
+            <Redirect
+              to={{
+                pathname: "/login",
+                state: { from: props.location }
+              }}
+            />
           )
         }
       />
-    )
+    );
   }
 }
 
 const PrivateRoute = connect(state => ({
   isAuthenticated: state.authReducer.isAuthenticated
-}))(PrivateRouteContainer)
+}))(PrivateRouteContainer);
 
 const Login = connect(null, dispatch => ({
   login: () => {
-    dispatch(authSuccess())
-    dispatch(push('/'))
+    dispatch(authSuccess());
+    dispatch(push("/"));
   }
-}))(LoginContainer)
+}))(LoginContainer);
 
 const Home = connect(null, dispatch => ({
   logout: () => {
-    dispatch(authFail())
-    dispatch(push('/login'))
+    dispatch(authFail());
+    dispatch(push("/login"));
   }
-}))(HomeContainer)
+}))(HomeContainer);
 
 render(
   <Provider store={store}>
@@ -119,5 +117,5 @@ render(
       </Switch>
     </ConnectedRouter>
   </Provider>,
-  document.getElementById('root'),
-)
+  document.getElementById("root")
+);

--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -26,7 +26,7 @@ class ConnectedRouter extends Component {
     });
   };
 
-  componentWillMount() {
+  componentDidMount() {
     const { store: propsStore, history, isSSR } = this.props;
     this.store = propsStore || this.context.store;
 

--- a/packages/react-router-redux/package-lock.json
+++ b/packages/react-router-redux/package-lock.json
@@ -12,7 +12,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "0.4.19"
 			}
 		},
 		"fbjs": {
@@ -20,13 +20,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.9"
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
 			},
 			"dependencies": {
 				"core-js": {
@@ -51,8 +51,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.4"
 			}
 		},
 		"js-tokens": {
@@ -65,7 +65,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"node-fetch": {
@@ -73,8 +73,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
 			}
 		},
 		"object-assign": {
@@ -87,7 +87,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "~2.0.3"
+				"asap": "2.0.6"
 			}
 		},
 		"prop-types": {
@@ -95,9 +95,9 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
 			}
 		},
 		"react-is": {
@@ -110,10 +110,10 @@
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.0.tgz",
 			"integrity": "sha512-Seh1t9xFY6TKiV/hRlPzUkqX1xHOiKIMsctfU0cggo1ajsLjoIJFL520LlrxV+4/VIj+clrCeH6s/aVv/vTStg==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0",
-				"react-is": "^16.4.0"
+				"fbjs": "0.8.16",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1",
+				"react-is": "16.4.0"
 			}
 		},
 		"setimmediate": {

--- a/packages/react-router/docs/api/history.md
+++ b/packages/react-router/docs/api/history.md
@@ -4,25 +4,25 @@ The term "history" and "`history` object" in this documentation refers to [the `
 
 The following terms are also used:
 
-- "browser history" - A DOM-specific implementation, useful in web browsers that support the HTML5 history API
-- "hash history" - A DOM-specific implementation for legacy web browsers
-- "memory history" - An in-memory history implementation, useful in testing and non-DOM environments like React Native
+* "browser history" - A DOM-specific implementation, useful in web browsers that support the HTML5 history API
+* "hash history" - A DOM-specific implementation for legacy web browsers
+* "memory history" - An in-memory history implementation, useful in testing and non-DOM environments like React Native
 
 `history` objects typically have the following properties and methods:
 
-- `length` - (number) The number of entries in the history stack
-- `action` - (string) The current action (`PUSH`, `REPLACE`, or `POP`)
-- `location` - (object) The current location. May have the following properties:
-  - `pathname` - (string) The path of the URL
-  - `search` - (string) The URL query string
-  - `hash` - (string) The URL hash fragment
-  - `state` - (object) location-specific state that was provided to e.g. `push(path, state)` when this location was pushed onto the stack. Only available in browser and memory history.
-- `push(path, [state])` - (function) Pushes a new entry onto the history stack
-- `replace(path, [state])` - (function) Replaces the current entry on the history stack
-- `go(n)` - (function) Moves the pointer in the history stack by `n` entries
-- `goBack()` - (function) Equivalent to `go(-1)`
-- `goForward()` - (function) Equivalent to `go(1)`
-- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history#blocking-transitions))
+* `length` - (number) The number of entries in the history stack
+* `action` - (string) The current action (`PUSH`, `REPLACE`, or `POP`)
+* `location` - (object) The current location. May have the following properties:
+  * `pathname` - (string) The path of the URL
+  * `search` - (string) The URL query string
+  * `hash` - (string) The URL hash fragment
+  * `state` - (object) location-specific state that was provided to e.g. `push(path, state)` when this location was pushed onto the stack. Only available in browser and memory history.
+* `push(path, [state])` - (function) Pushes a new entry onto the history stack
+* `replace(path, [state])` - (function) Replaces the current entry on the history stack
+* `go(n)` - (function) Moves the pointer in the history stack by `n` entries
+* `goBack()` - (function) Equivalent to `go(-1)`
+* `goForward()` - (function) Equivalent to `go(1)`
+* `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history#blocking-transitions))
 
 ## history is mutable
 
@@ -30,16 +30,17 @@ The history object is mutable. Therefore it is recommended to access the [`locat
 
 ```jsx
 class Comp extends React.Component {
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     // will be true
-    const locationChanged = nextProps.location !== this.props.location
+    const locationChanged = prevProps.location !== this.props.location;
 
     // INCORRECT, will *always* be false because history is mutable.
-    const locationChanged = nextProps.history.location !== this.props.history.location
+    const locationChanged =
+      prevProps.history.location !== this.props.history.location;
   }
 }
 
-<Route component={Comp}/>
+<Route component={Comp} />;
 ```
 
 Additional properties may also be present depending on the implementation you're using. Please refer to [the history documentation](https://github.com/ReactTraining/history#properties) for more details.

--- a/packages/react-router/docs/api/location.md
+++ b/packages/react-router/docs/api/location.md
@@ -17,18 +17,18 @@ even where it was. It looks like this:
 
 The router will provide you with a location object in a few places:
 
-- [Route component](./Route.md#component) as `this.props.location`
-- [Route render](./Route.md#render-func) as `({ location }) => ()`
-- [Route children](./Route.md#children-func) as `({ location }) => ()`
-- [withRouter](./withRouter.md) as `this.props.location`
+* [Route component](./Route.md#component) as `this.props.location`
+* [Route render](./Route.md#render-func) as `({ location }) => ()`
+* [Route children](./Route.md#children-func) as `({ location }) => ()`
+* [withRouter](./withRouter.md) as `this.props.location`
 
 It is also found on `history.location` but you shouldn't use that because its mutable. You can read more about that in the [history](./history.md) doc.
 
 A location object is never mutated so you can use it in the lifecycle hooks to determine when navigation happens, this is really useful for data fetching and animation.
 
 ```js
-componentWillReceiveProps(nextProps) {
-  if (nextProps.location !== this.props.location) {
+componentDidUpdate(prevProps) {
+  if (prevProps.location !== this.props.location) {
     // navigated!
   }
 }
@@ -36,11 +36,11 @@ componentWillReceiveProps(nextProps) {
 
 You can provide locations instead of strings to the various places that navigate:
 
-- Web [Link to](../../../react-router-dom/docs/api/Link.md#to)
-- Native [Link to](../../../react-router-native/docs/api/Link.md#to)
-- [Redirect to](./Redirect.md#to)
-- [history.push](./history.md#push)
-- [history.replace](./history.md#push)
+* Web [Link to](../../../react-router-dom/docs/api/Link.md#to)
+* Native [Link to](../../../react-router-native/docs/api/Link.md#to)
+* [Redirect to](./Redirect.md#to)
+* [history.push](./history.md#push)
+* [history.replace](./history.md#push)
 
 Normally you just use a string, but if you need to add some "location state" that will be available whenever the app returns to that specific location, you can use a location object instead. This is useful if you want to branch UI based on navigation history instead of just paths (like modals).
 
@@ -62,8 +62,7 @@ history.replace(location)
 
 Finally, you can pass a location to the following components:
 
-- [Route](./Route.md#location)
-- [Switch](./Switch.md#location)
+* [Route](./Route.md#location)
+* [Switch](./Switch.md#location)
 
 This will prevent them from using the actual location in the router's state. This is useful for animation and pending navigation, or any time you want to trick a component into rendering at a different location than the real one.
-

--- a/packages/react-router/docs/guides/migrating.md
+++ b/packages/react-router/docs/guides/migrating.md
@@ -9,7 +9,7 @@ React Router v4 is a complete rewrite, so there is not a simple migration path. 
 * [The Router](#the-router)
 * [Routes](#routes)
   * [Nesting Routes](#nesting-routes)
-  * [on* properties](#on-properties)
+  * [on\* properties](#on-properties)
   * [Optional Parameters](#optional-parameters)
   * [Query Strings](#query-strings)
   * [Switch](#switch)
@@ -43,8 +43,8 @@ In v4, there is no centralized route configuration. Anywhere that you need to re
 //v4
 <BrowserRouter>
   <div>
-    <Route path='/about' component={About} />
-    <Route path='/contact' component={Contact} />
+    <Route path="/about" component={About} />
+    <Route path="/contact" component={Contact} />
   </div>
 </BrowserRouter>
 ```
@@ -90,9 +90,9 @@ The v4 `<Route>` component is actually a component, so wherever you render a `<R
 In v3, `<Route>`s were nested by passing them as the `children` of their parent `<Route>`.
 
 ```jsx
-<Route path='parent' component={Parent}>
-  <Route path='child' component={Child} />
-  <Route path='other' component={Other} />
+<Route path="parent" component={Parent}>
+  <Route path="child" component={Child} />
+  <Route path="other" component={Other} />
 </Route>
 ```
 
@@ -107,21 +107,21 @@ When a nested `<Route>` matched, React elements would be created using both the 
 With v4, children `<Route>`s should just be rendered by the parent `<Route>`'s component.
 
 ```jsx
-<Route path='parent' component={Parent} />
+<Route path="parent" component={Parent} />;
 
 const Parent = () => (
   <div>
-    <Route path='child' component={Child} />
-    <Route path='other' component={Other} />
+    <Route path="child" component={Child} />
+    <Route path="other" component={Other} />
   </div>
-)
+);
 ```
 
 ### `on*` properties
 
 React Router v3 provides `onEnter`, `onUpdate`, and `onLeave` methods. These were essentially recreating React's lifecycle methods.
 
-With v4, you should use the lifecycle methods of the component rendered by a `<Route>`. Instead of `onEnter`, you would use `componentDidMount` or `componentWillMount`. Where you would use `onUpdate`, you can use `componentDidUpdate` or `componentWillUpdate` (or possibly `componentWillReceiveProps`). `onLeave` can be replaced with `componentWillUnmount`.
+With v4, you should use the lifecycle methods of the component rendered by a `<Route>`. Instead of `onEnter`, you would use `componentDidMount`. Where you would use `onUpdate`, you can use `componentDidUpdate` or `componentWillUpdate` (or possibly `componentWillReceiveProps` or `static getDerivedStateFromProps`). `onLeave` can be replaced with `componentWillUnmount`.
 
 ### Optional Parameters
 
@@ -143,10 +143,10 @@ In v3, you could specify a number of child routes, and only the first one that m
 
 ```jsx
 // v3
-<Route path='/' component={App}>
+<Route path="/" component={App}>
   <IndexRoute component={Home} />
-  <Route path='about' component={About} />
-  <Route path='contact' component={Contact} />
+  <Route path="about" component={About} />
+  <Route path="contact" component={Contact} />
 </Route>
 ```
 
@@ -156,12 +156,11 @@ v4 provides a similar functionality with the `<Switch>` component. When a `<Swit
 // v4
 const App = () => (
   <Switch>
-    <Route exact path='/' component={Home} />
-    <Route path='/about' component={About} />
-    <Route path='/contact' component={Contact} />
+    <Route exact path="/" component={Home} />
+    <Route path="/about" component={About} />
+    <Route path="/contact" component={Contact} />
   </Switch>
-)
-
+);
 ```
 
 ### `<Redirect>`
@@ -173,7 +172,6 @@ In v3, if you wanted to redirect from one path to another, for instance / to /we
 <Route path="/" component={App}>
   <IndexRedirect to="/welcome" />
 </Route>
-
 ```
 
 In v4, you can achieve the same functionality using `<Redirect>`.
@@ -187,7 +185,6 @@ In v4, you can achieve the same functionality using `<Redirect>`.
   <Route path="/login" component={Login} />
   <Redirect path="*" to="/" />
 </Switch>
-
 ```
 
 In v3, `<Redirect>` preserved the query string:
@@ -214,27 +211,29 @@ In v4, you must re-pass these properties to the `to` prop:
 ## PatternUtils
 
 ### matchPattern(pattern, pathname)
+
 In v3, you could use the same matching code used internally to check if a path matched a pattern. In v4 this has been replaced by [matchPath](/packages/react-router/docs/api/matchPath.md) which is powered by the [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) library.
 
 ### formatPattern(pattern, params)
+
 In v3, you could use PatternUtils.formatPattern to generate a valid path from a path pattern (perhaps in a constant or in your central routing config) and an object containing the names parameters:
 
 ```jsx
 // v3
-const THING_PATH = '/thing/:id';
+const THING_PATH = "/thing/:id";
 
-<Link to={PatternUtils.formatPattern(THING_PATH, {id: 1})}>A thing</Link>
+<Link to={PatternUtils.formatPattern(THING_PATH, { id: 1 })}>A thing</Link>;
 ```
 
 In v4, you can achieve the same functionality using the [`compile`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#compile-reverse-path-to-regexp) function in [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0).
 
 ```jsx
 // v4
-const THING_PATH = '/thing/:id';
+const THING_PATH = "/thing/:id";
 
 const thingPath = pathToRegexp.compile(THING_PATH);
 
-<Link to={thingPath({id: 1})}>A thing</Link>
+<Link to={thingPath({ id: 1 })}>A thing</Link>;
 ```
 
 ### getParamNames
@@ -244,6 +243,7 @@ The `getParamNames` functionality can be achieved using the [`parse`](https://gi
 ## Link
 
 ### `to` property is required
+
 In v3, you could omit `to` property or set it to null to create an anchor tag without `href` attribute.
 
 ```jsx

--- a/packages/react-router/modules/MemoryRouter.js
+++ b/packages/react-router/modules/MemoryRouter.js
@@ -18,7 +18,7 @@ class MemoryRouter extends React.Component {
 
   history = createHistory(this.props);
 
-  componentWillMount() {
+  componentDidMount() {
     warning(
       !this.props.history,
       "<MemoryRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router/modules/Prompt.js
+++ b/packages/react-router/modules/Prompt.js
@@ -37,7 +37,7 @@ class Prompt extends React.Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     invariant(
       this.context.router,
       "You should not use <Prompt> outside a <Router>"
@@ -46,10 +46,10 @@ class Prompt extends React.Component {
     if (this.props.when) this.enable(this.props.message);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.when) {
-      if (!this.props.when || this.props.message !== nextProps.message)
-        this.enable(nextProps.message);
+  componentDidUpdate(prevProps) {
+    if (this.props.when) {
+      if (!prevProps.when || prevProps.message !== this.props.message)
+        this.enable(this.props.message);
     } else {
       this.disable();
     }

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -31,8 +31,16 @@ class Redirect extends React.Component {
     }).isRequired
   };
 
+  constructor(props, context) {
+    super(props, context);
+
+    if (this.isStatic()) this.perform();
+  }
+
   isStatic() {
-    return this.context.router && this.context.router.staticContext;
+    return (
+      this.context && this.context.router && this.context.router.staticContext
+    );
   }
 
   componentDidMount() {
@@ -40,8 +48,7 @@ class Redirect extends React.Component {
       this.context.router,
       "You should not use <Redirect> outside a <Router>"
     );
-
-    if (this.isStatic()) this.perform();
+    if (!this.isStatic()) this.perform();
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -35,17 +35,13 @@ class Redirect extends React.Component {
     return this.context.router && this.context.router.staticContext;
   }
 
-  componentWillMount() {
+  componentDidMount() {
     invariant(
       this.context.router,
       "You should not use <Redirect> outside a <Router>"
     );
 
     if (this.isStatic()) this.perform();
-  }
-
-  componentDidMount() {
-    if (!this.isStatic()) this.perform();
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -3,6 +3,7 @@ import invariant from "invariant";
 import React from "react";
 import PropTypes from "prop-types";
 import matchPath from "./matchPath";
+import isEqual from "lodash.isequal";
 
 const isEmptyChildren = children => React.Children.count(children) === 0;
 
@@ -103,9 +104,13 @@ class Route extends React.Component {
       '<Route> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
     );
 
-    this.setState({
-      match: this.computeMatch(this.props, this.context.router)
-    });
+    const newMatch = this.computeMatch(this.props, this.context.router);
+
+    if (!isEqual(newMatch, this.state.match)) {
+      this.setState({
+        match: newMatch
+      });
+    }
   }
 
   render() {

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -67,7 +67,7 @@ class Route extends React.Component {
     return matchPath(pathname, { path, strict, exact, sensitive }, route.match);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     warning(
       !(this.props.component && this.props.render),
       "You should not use <Route component> and <Route render> in the same route; <Route render> will be ignored"
@@ -92,19 +92,19 @@ class Route extends React.Component {
     );
   }
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentDidUpdate(prevProps) {
     warning(
-      !(nextProps.location && !this.props.location),
+      !(prevProps.location && !this.props.location),
       '<Route> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'
     );
 
     warning(
-      !(!nextProps.location && this.props.location),
+      !(!prevProps.location && this.props.location),
       '<Route> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
     );
 
     this.setState({
-      match: this.computeMatch(nextProps, nextContext.router)
+      match: this.computeMatch(this.props, this.context.router)
     });
   }
 

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -20,6 +20,26 @@ class Router extends React.Component {
     router: PropTypes.object.isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    const { children, history } = props;
+
+    invariant(
+      children == null || React.Children.count(children) === 1,
+      "A <Router> may have only one child element"
+    );
+
+    // Do this here so we can setState when a <Redirect> changes the
+    // location in componentDidMount. This happens e.g. when doing
+    // server rendering using a <StaticRouter>.
+    this.unlisten = history.listen(() => {
+      this.setState({
+        match: this.computeMatch(history.location.pathname)
+      });
+    });
+  }
+
   getChildContext() {
     return {
       router: {
@@ -44,24 +64,6 @@ class Router extends React.Component {
       params: {},
       isExact: pathname === "/"
     };
-  }
-
-  componentDidMount() {
-    const { children, history } = this.props;
-
-    invariant(
-      children == null || React.Children.count(children) === 1,
-      "A <Router> may have only one child element"
-    );
-
-    // Do this here so we can setState when a <Redirect> changes the
-    // location in componentDidMount. This happens e.g. when doing
-    // server rendering using a <StaticRouter>.
-    this.unlisten = history.listen(() => {
-      this.setState({
-        match: this.computeMatch(history.location.pathname)
-      });
-    });
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -46,7 +46,7 @@ class Router extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { children, history } = this.props;
 
     invariant(
@@ -55,7 +55,7 @@ class Router extends React.Component {
     );
 
     // Do this here so we can setState when a <Redirect> changes the
-    // location in componentWillMount. This happens e.g. when doing
+    // location in componentDidMount. This happens e.g. when doing
     // server rendering using a <StaticRouter>.
     this.unlisten = history.listen(() => {
       this.setState({
@@ -64,9 +64,9 @@ class Router extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     warning(
-      this.props.history === nextProps.history,
+      this.props.history === prevProps.history,
       "You cannot change <Router history>"
     );
   }

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -90,7 +90,7 @@ class StaticRouter extends React.Component {
 
   handleBlock = () => noop;
 
-  componentWillMount() {
+  componentDidMount() {
     warning(
       !this.props.history,
       "<StaticRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -19,21 +19,21 @@ class Switch extends React.Component {
     location: PropTypes.object
   };
 
-  componentWillMount() {
+  componentDidMount() {
     invariant(
       this.context.router,
       "You should not use <Switch> outside a <Router>"
     );
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     warning(
-      !(nextProps.location && !this.props.location),
+      !(prevProps.location && !this.props.location),
       '<Switch> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'
     );
 
     warning(
-      !(!nextProps.location && this.props.location),
+      !(!prevProps.location && this.props.location),
       '<Switch> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
     );
   }

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -19,11 +19,10 @@ class Switch extends React.Component {
     location: PropTypes.object
   };
 
-  componentDidMount() {
-    invariant(
-      this.context.router,
-      "You should not use <Switch> outside a <Router>"
-    );
+  constructor(props, context) {
+    super(props);
+
+    invariant(context.router, "You should not use <Switch> outside a <Router>");
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/react-router/modules/__tests__/SwitchMount-test.js
+++ b/packages/react-router/modules/__tests__/SwitchMount-test.js
@@ -12,7 +12,7 @@ describe("A <Switch>", () => {
     let mountCount = 0;
 
     class App extends React.Component {
-      componentWillMount() {
+      componentDidMount() {
         mountCount++;
       }
 

--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-router",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -20,10 +20,10 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.44",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.2.0",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"jsesc": "2.5.1",
+				"lodash": "4.17.4",
+				"source-map": "0.5.6",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -69,9 +69,9 @@
 			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"chalk": "2.4.1",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -80,7 +80,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -89,9 +89,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -100,7 +100,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -114,7 +114,7 @@
 				"@babel/code-frame": "7.0.0-beta.44",
 				"@babel/types": "7.0.0-beta.44",
 				"babylon": "7.0.0-beta.44",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.4"
 			},
 			"dependencies": {
 				"babylon": {
@@ -137,10 +137,10 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
 				"@babel/types": "7.0.0-beta.44",
 				"babylon": "7.0.0-beta.44",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
+				"debug": "3.1.0",
+				"globals": "11.4.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.4"
 			},
 			"dependencies": {
 				"babylon": {
@@ -172,9 +172,9 @@
 			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^2.0.0"
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "2.0.0"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -215,7 +215,7 @@
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0"
+				"acorn": "5.5.3"
 			}
 		},
 		"acorn-jsx": {
@@ -224,7 +224,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "^3.0.4"
+				"acorn": "3.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -241,10 +241,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
@@ -259,9 +259,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"amdefine": {
@@ -295,8 +295,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"append-transform": {
@@ -305,7 +305,7 @@
 			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^2.0.0"
+				"default-require-extensions": "2.0.0"
 			}
 		},
 		"argparse": {
@@ -314,7 +314,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -323,7 +323,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.0.1"
+				"arr-flatten": "1.1.0"
 			}
 		},
 		"arr-flatten": {
@@ -350,8 +350,8 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.12.0"
 			}
 		},
 		"array-union": {
@@ -360,7 +360,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -416,7 +416,7 @@
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "4.17.10"
 			},
 			"dependencies": {
 				"lodash": {
@@ -470,21 +470,21 @@
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-polyfill": "^6.26.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"chokidar": "^1.6.1",
-				"commander": "^2.11.0",
-				"convert-source-map": "^1.5.0",
-				"fs-readdir-recursive": "^1.0.0",
-				"glob": "^7.1.2",
-				"lodash": "^4.17.4",
-				"output-file-sync": "^1.1.2",
-				"path-is-absolute": "^1.0.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6",
-				"v8flags": "^2.1.1"
+				"babel-core": "6.26.0",
+				"babel-polyfill": "6.26.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"chokidar": "1.7.0",
+				"commander": "2.11.0",
+				"convert-source-map": "1.5.0",
+				"fs-readdir-recursive": "1.0.0",
+				"glob": "7.1.2",
+				"lodash": "4.17.4",
+				"output-file-sync": "1.1.2",
+				"path-is-absolute": "1.0.1",
+				"slash": "1.0.0",
+				"source-map": "0.5.6",
+				"v8flags": "2.1.1"
 			},
 			"dependencies": {
 				"babel-code-frame": {
@@ -493,9 +493,9 @@
 					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"babel-core": {
@@ -504,25 +504,25 @@
 					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-generator": "^6.26.0",
-						"babel-helpers": "^6.24.1",
-						"babel-messages": "^6.23.0",
-						"babel-register": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"babel-template": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"convert-source-map": "^1.5.0",
-						"debug": "^2.6.8",
-						"json5": "^0.5.1",
-						"lodash": "^4.17.4",
-						"minimatch": "^3.0.4",
-						"path-is-absolute": "^1.0.1",
-						"private": "^0.1.7",
-						"slash": "^1.0.0",
-						"source-map": "^0.5.6"
+						"babel-code-frame": "6.26.0",
+						"babel-generator": "6.26.0",
+						"babel-helpers": "6.24.1",
+						"babel-messages": "6.23.0",
+						"babel-register": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"convert-source-map": "1.5.0",
+						"debug": "2.6.8",
+						"json5": "0.5.1",
+						"lodash": "4.17.4",
+						"minimatch": "3.0.4",
+						"path-is-absolute": "1.0.1",
+						"private": "0.1.7",
+						"slash": "1.0.0",
+						"source-map": "0.5.6"
 					}
 				},
 				"babel-generator": {
@@ -531,14 +531,14 @@
 					"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
 					"dev": true,
 					"requires": {
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"detect-indent": "^4.0.0",
-						"jsesc": "^1.3.0",
-						"lodash": "^4.17.4",
-						"source-map": "^0.5.6",
-						"trim-right": "^1.0.1"
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.4",
+						"source-map": "0.5.6",
+						"trim-right": "1.0.1"
 					}
 				},
 				"babel-register": {
@@ -547,13 +547,13 @@
 					"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 					"dev": true,
 					"requires": {
-						"babel-core": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"core-js": "^2.5.0",
-						"home-or-tmp": "^2.0.0",
-						"lodash": "^4.17.4",
-						"mkdirp": "^0.5.1",
-						"source-map-support": "^0.4.15"
+						"babel-core": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"core-js": "2.5.0",
+						"home-or-tmp": "2.0.0",
+						"lodash": "4.17.4",
+						"mkdirp": "0.5.1",
+						"source-map-support": "0.4.15"
 					},
 					"dependencies": {
 						"core-js": {
@@ -570,8 +570,8 @@
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 					"dev": true,
 					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
+						"core-js": "2.4.1",
+						"regenerator-runtime": "0.11.0"
 					}
 				},
 				"babel-template": {
@@ -580,11 +580,11 @@
 					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"lodash": "^4.17.4"
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.4"
 					}
 				},
 				"babel-traverse": {
@@ -593,15 +593,15 @@
 					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"debug": "^2.6.8",
-						"globals": "^9.18.0",
-						"invariant": "^2.2.2",
-						"lodash": "^4.17.4"
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.8",
+						"globals": "9.18.0",
+						"invariant": "2.2.4",
+						"lodash": "4.17.4"
 					}
 				},
 				"babel-types": {
@@ -610,10 +610,10 @@
 					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.26.0",
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.4",
-						"to-fast-properties": "^1.0.3"
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "1.0.3"
 					}
 				},
 				"babylon": {
@@ -636,9 +636,9 @@
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"babel-core": {
@@ -647,25 +647,25 @@
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"babel-code-frame": {
@@ -674,9 +674,9 @@
 					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"babel-runtime": {
@@ -685,8 +685,8 @@
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 					"dev": true,
 					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
+						"core-js": "2.4.1",
+						"regenerator-runtime": "0.11.1"
 					}
 				},
 				"babel-template": {
@@ -695,11 +695,11 @@
 					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"lodash": "^4.17.4"
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.4"
 					}
 				},
 				"babel-traverse": {
@@ -708,15 +708,15 @@
 					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"debug": "^2.6.8",
-						"globals": "^9.18.0",
-						"invariant": "^2.2.2",
-						"lodash": "^4.17.4"
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.4",
+						"lodash": "4.17.4"
 					}
 				},
 				"babel-types": {
@@ -725,10 +725,10 @@
 					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.26.0",
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.4",
-						"to-fast-properties": "^1.0.3"
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "1.0.3"
 					}
 				},
 				"babylon": {
@@ -782,8 +782,8 @@
 				"@babel/traverse": "7.0.0-beta.44",
 				"@babel/types": "7.0.0-beta.44",
 				"babylon": "7.0.0-beta.44",
-				"eslint-scope": "~3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0"
 			},
 			"dependencies": {
 				"babylon": {
@@ -800,14 +800,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.4",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"babel-runtime": {
@@ -816,8 +816,8 @@
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 					"dev": true,
 					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
+						"core-js": "2.4.1",
+						"regenerator-runtime": "0.11.1"
 					}
 				},
 				"babel-types": {
@@ -826,10 +826,10 @@
 					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "^6.26.0",
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.4",
-						"to-fast-properties": "^1.0.3"
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "1.0.3"
 					}
 				},
 				"regenerator-runtime": {
@@ -852,9 +852,9 @@
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -863,9 +863,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -874,9 +874,9 @@
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1",
-				"esutils": "^2.0.0"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0",
+				"esutils": "2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -885,10 +885,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-define-map": {
@@ -897,10 +897,10 @@
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1",
-				"lodash": "^4.2.0"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -909,9 +909,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -920,10 +920,10 @@
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"dev": true,
 			"requires": {
-				"babel-helper-bindify-decorators": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-bindify-decorators": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -932,11 +932,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -945,8 +945,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -955,8 +955,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -965,8 +965,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -975,9 +975,9 @@
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1",
-				"lodash": "^4.2.0"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -986,11 +986,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -999,12 +999,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-helpers": {
@@ -1013,8 +1013,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0"
 			}
 		},
 		"babel-jest": {
@@ -1023,8 +1023,8 @@
 			"integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.6",
-				"babel-preset-jest": "^23.0.1"
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-preset-jest": "23.0.1"
 			}
 		},
 		"babel-messages": {
@@ -1033,7 +1033,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -1042,7 +1042,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-dev-expression": {
@@ -1057,7 +1057,7 @@
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -1066,10 +1066,10 @@
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"test-exclude": "4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -1156,9 +1156,9 @@
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-generators": "^6.5.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-generators": "6.13.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -1167,9 +1167,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -1178,9 +1178,9 @@
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-syntax-class-constructor-call": "6.18.0",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1189,10 +1189,10 @@
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -1201,11 +1201,11 @@
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-class": "^6.24.1",
-				"babel-plugin-syntax-decorators": "^6.13.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-class": "6.24.1",
+				"babel-plugin-syntax-decorators": "6.13.0",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1214,7 +1214,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1223,7 +1223,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1232,11 +1232,11 @@
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1",
-				"lodash": "^4.2.0"
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1245,15 +1245,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-define-map": "6.24.1",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1262,8 +1262,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1272,7 +1272,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1281,8 +1281,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1291,7 +1291,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1300,9 +1300,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1311,7 +1311,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1320,9 +1320,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1331,10 +1331,10 @@
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1343,9 +1343,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1354,9 +1354,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1365,8 +1365,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1375,12 +1375,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1389,8 +1389,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1399,7 +1399,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1408,9 +1408,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1419,7 +1419,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1428,7 +1428,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1437,9 +1437,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.24.1",
+				"babel-runtime": "6.25.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1448,9 +1448,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1459,8 +1459,8 @@
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-export-extensions": "6.13.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1469,8 +1469,8 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1479,8 +1479,8 @@
 			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -1489,7 +1489,7 @@
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -1498,9 +1498,9 @@
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-react-jsx": "6.24.1",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-self": {
@@ -1509,8 +1509,8 @@
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -1519,8 +1519,8 @@
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.25.0"
 			}
 		},
 		"babel-plugin-transform-react-remove-prop-types": {
@@ -1544,8 +1544,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0"
 			}
 		},
 		"babel-polyfill": {
@@ -1554,9 +1554,9 @@
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.0",
+				"regenerator-runtime": "0.10.5"
 			},
 			"dependencies": {
 				"babel-runtime": {
@@ -1565,8 +1565,8 @@
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 					"dev": true,
 					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
+						"core-js": "2.5.0",
+						"regenerator-runtime": "0.11.0"
 					},
 					"dependencies": {
 						"regenerator-runtime": {
@@ -1591,30 +1591,30 @@
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-				"babel-plugin-transform-es2015-classes": "^6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-				"babel-plugin-transform-es2015-for-of": "^6.22.0",
-				"babel-plugin-transform-es2015-function-name": "^6.24.1",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-				"babel-plugin-transform-es2015-object-super": "^6.24.1",
-				"babel-plugin-transform-es2015-parameters": "^6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-				"babel-plugin-transform-regenerator": "^6.24.1"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.24.1",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.24.1"
 			}
 		},
 		"babel-preset-flow": {
@@ -1623,7 +1623,7 @@
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.22.0"
+				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
 		},
 		"babel-preset-jest": {
@@ -1632,8 +1632,8 @@
 			"integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^23.0.1",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"babel-plugin-jest-hoist": "23.0.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
 			}
 		},
 		"babel-preset-react": {
@@ -1642,12 +1642,12 @@
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.3.13",
-				"babel-plugin-transform-react-display-name": "^6.23.0",
-				"babel-plugin-transform-react-jsx": "^6.24.1",
-				"babel-plugin-transform-react-jsx-self": "^6.22.0",
-				"babel-plugin-transform-react-jsx-source": "^6.22.0",
-				"babel-preset-flow": "^6.23.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-self": "6.22.0",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-preset-flow": "6.23.0"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1656,9 +1656,9 @@
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "^6.24.1",
-				"babel-plugin-transform-export-extensions": "^6.22.0",
-				"babel-preset-stage-2": "^6.24.1"
+				"babel-plugin-transform-class-constructor-call": "6.24.1",
+				"babel-plugin-transform-export-extensions": "6.22.0",
+				"babel-preset-stage-2": "6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1667,10 +1667,10 @@
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "^6.18.0",
-				"babel-plugin-transform-class-properties": "^6.24.1",
-				"babel-plugin-transform-decorators": "^6.24.1",
-				"babel-preset-stage-3": "^6.24.1"
+				"babel-plugin-syntax-dynamic-import": "6.18.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-decorators": "6.24.1",
+				"babel-preset-stage-3": "6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1679,11 +1679,11 @@
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-generator-functions": "^6.24.1",
-				"babel-plugin-transform-async-to-generator": "^6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
-				"babel-plugin-transform-object-rest-spread": "^6.22.0"
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-generator-functions": "6.24.1",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-object-rest-spread": "6.23.0"
 			}
 		},
 		"babel-register": {
@@ -1692,13 +1692,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.3",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.7",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.15"
 			},
 			"dependencies": {
 				"babel-runtime": {
@@ -1707,8 +1707,8 @@
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 					"dev": true,
 					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
+						"core-js": "2.5.7",
+						"regenerator-runtime": "0.11.1"
 					}
 				},
 				"core-js": {
@@ -1731,8 +1731,8 @@
 			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.10.0"
+				"core-js": "2.4.1",
+				"regenerator-runtime": "0.10.5"
 			}
 		},
 		"babel-template": {
@@ -1741,11 +1741,11 @@
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.25.0",
-				"babel-types": "^6.25.0",
-				"babylon": "^6.17.2",
-				"lodash": "^4.2.0"
+				"babel-runtime": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1754,15 +1754,15 @@
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.22.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.25.0",
-				"babylon": "^6.17.2",
-				"debug": "^2.2.0",
-				"globals": "^9.0.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
+				"babel-code-frame": "6.22.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4",
+				"debug": "2.6.8",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.4"
 			}
 		},
 		"babel-types": {
@@ -1771,10 +1771,10 @@
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^1.0.1"
+				"babel-runtime": "6.25.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -1795,13 +1795,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1810,7 +1810,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1819,7 +1819,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1828,7 +1828,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1837,9 +1837,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -1863,7 +1863,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"binary-extensions": {
@@ -1879,7 +1879,7 @@
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1889,9 +1889,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
 			}
 		},
 		"browser-process-hrtime": {
@@ -1923,7 +1923,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer-from": {
@@ -1944,15 +1944,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -1969,7 +1969,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			}
 		},
 		"callsites": {
@@ -1991,7 +1991,7 @@
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
 			"requires": {
-				"rsvp": "^3.3.3"
+				"rsvp": "3.6.2"
 			}
 		},
 		"caseless": {
@@ -2007,8 +2007,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
 			}
 		},
 		"chalk": {
@@ -2017,11 +2017,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
 			}
 		},
 		"chardet": {
@@ -2037,15 +2037,15 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"anymatch": "^1.3.0",
-				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.1.2",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
 			}
 		},
 		"ci-info": {
@@ -2066,10 +2066,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2078,7 +2078,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"isobject": {
@@ -2095,7 +2095,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-width": {
@@ -2111,8 +2111,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"center-align": "^0.1.1",
-				"right-align": "^0.1.1",
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
 				"wordwrap": "0.0.2"
 			},
 			"dependencies": {
@@ -2143,8 +2143,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color-convert": {
@@ -2153,7 +2153,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -2168,7 +2168,7 @@
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -2201,10 +2201,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"buffer-from": "1.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
 			}
 		},
 		"contains-path": {
@@ -2243,9 +2243,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.2",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
 			}
 		},
 		"cssom": {
@@ -2260,7 +2260,7 @@
 			"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "0.3.2"
 			}
 		},
 		"dashdash": {
@@ -2269,7 +2269,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"data-urls": {
@@ -2278,9 +2278,9 @@
 			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"whatwg-mimetype": "^2.0.0",
-				"whatwg-url": "^6.4.0"
+				"abab": "1.0.4",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1"
 			}
 		},
 		"debug": {
@@ -2316,7 +2316,7 @@
 			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "^3.0.0"
+				"strip-bom": "3.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -2333,8 +2333,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
 			}
 		},
 		"define-property": {
@@ -2343,8 +2343,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -2353,7 +2353,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2362,7 +2362,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2371,9 +2371,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -2396,13 +2396,13 @@
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"dev": true,
 			"requires": {
-				"globby": "^5.0.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"rimraf": "^2.2.8"
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"delayed-stream": {
@@ -2417,7 +2417,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-newline": {
@@ -2438,7 +2438,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.2"
 			}
 		},
 		"domexception": {
@@ -2447,7 +2447,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"duplexer": {
@@ -2463,7 +2463,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "0.1.1"
 			}
 		},
 		"encoding": {
@@ -2471,7 +2471,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "0.4.21"
 			}
 		},
 		"error-ex": {
@@ -2480,7 +2480,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -2489,11 +2489,11 @@
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.3",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -2502,9 +2502,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -2519,11 +2519,11 @@
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -2547,44 +2547,44 @@
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
-				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.4",
-				"esquery": "^1.0.0",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
-				"progress": "^2.0.0",
-				"regexpp": "^1.0.1",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.22.0",
+				"chalk": "2.4.1",
+				"concat-stream": "1.6.2",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.4.0",
+				"ignore": "3.3.8",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.11.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"regexpp": "1.1.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.5.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
 				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2599,7 +2599,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -2608,9 +2608,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"debug": {
@@ -2634,7 +2634,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -2643,7 +2643,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -2654,8 +2654,8 @@
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
-				"resolve": "^1.5.0"
+				"debug": "2.6.9",
+				"resolve": "1.7.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -2675,8 +2675,8 @@
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"pkg-dir": "^1.0.0"
+				"debug": "2.6.8",
+				"pkg-dir": "1.0.0"
 			}
 		},
 		"eslint-plugin-import": {
@@ -2685,16 +2685,16 @@
 			"integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
 			"dev": true,
 			"requires": {
-				"contains-path": "^0.1.0",
-				"debug": "^2.6.8",
+				"contains-path": "0.1.0",
+				"debug": "2.6.8",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.2.0",
-				"has": "^1.0.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.3",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.6.0"
+				"eslint-import-resolver-node": "0.3.2",
+				"eslint-module-utils": "2.2.0",
+				"has": "1.0.3",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"read-pkg-up": "2.0.0",
+				"resolve": "1.7.1"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -2703,8 +2703,8 @@
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "2.0.2",
+						"isarray": "1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -2713,10 +2713,10 @@
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"path-type": {
@@ -2725,7 +2725,7 @@
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"dev": true,
 					"requires": {
-						"pify": "^2.0.0"
+						"pify": "2.3.0"
 					}
 				},
 				"read-pkg": {
@@ -2734,9 +2734,9 @@
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2745,8 +2745,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -2763,10 +2763,10 @@
 			"integrity": "sha512-uvq+2ZkiqzjwF+pMZ8xqIC3pChV4KviPvvPIyQOvKWnjtvyW3iGfHIRqVumw05L3itby0QGmA4VdBA9m1OdMmg==",
 			"dev": true,
 			"requires": {
-				"doctrine": "^2.1.0",
-				"has": "^1.0.2",
-				"jsx-ast-utils": "^2.0.1",
-				"prop-types": "^15.6.1"
+				"doctrine": "2.1.0",
+				"has": "1.0.3",
+				"jsx-ast-utils": "2.0.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"eslint-scope": {
@@ -2775,8 +2775,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -2791,8 +2791,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "5.5.3",
+				"acorn-jsx": "3.0.1"
 			}
 		},
 		"esprima": {
@@ -2807,7 +2807,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -2816,7 +2816,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"estraverse": {
@@ -2843,7 +2843,7 @@
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"dev": true,
 			"requires": {
-				"merge": "^1.1.3"
+				"merge": "1.2.0"
 			}
 		},
 		"execa": {
@@ -2852,13 +2852,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"exit": {
@@ -2873,7 +2873,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"is-posix-bracket": "0.1.1"
 			}
 		},
 		"expand-range": {
@@ -2882,7 +2882,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.3"
 			}
 		},
 		"expect": {
@@ -2891,12 +2891,12 @@
 			"integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"jest-diff": "^23.0.1",
-				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^23.0.1",
-				"jest-message-util": "^23.1.0",
-				"jest-regex-util": "^23.0.0"
+				"ansi-styles": "3.2.1",
+				"jest-diff": "23.0.1",
+				"jest-get-type": "22.4.3",
+				"jest-matcher-utils": "23.0.1",
+				"jest-message-util": "23.1.0",
+				"jest-regex-util": "23.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -2905,7 +2905,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -2922,8 +2922,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -2932,7 +2932,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -2943,9 +2943,9 @@
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.21",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -2954,7 +2954,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -2987,7 +2987,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.0.0"
 			}
 		},
 		"fbjs": {
@@ -2995,13 +2995,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.9"
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
 			},
 			"dependencies": {
 				"core-js": {
@@ -3017,7 +3017,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -3026,8 +3026,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"filename-regex": {
@@ -3042,8 +3042,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
 			}
 		},
 		"fill-range": {
@@ -3052,11 +3052,11 @@
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^1.1.3",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"find-up": {
@@ -3065,7 +3065,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -3074,10 +3074,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
 			}
 		},
 		"for-in": {
@@ -3092,7 +3092,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"foreach": {
@@ -3113,9 +3113,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
+				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "^2.1.12"
+				"mime-types": "2.1.18"
 			}
 		},
 		"fragment-cache": {
@@ -3124,7 +3124,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"fs-readdir-recursive": {
@@ -3146,8 +3146,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.3.0",
-				"node-pre-gyp": "^0.6.36"
+				"nan": "2.6.2",
+				"node-pre-gyp": "0.6.36"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3162,8 +3162,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
 					}
 				},
 				"ansi-regex": {
@@ -3183,8 +3183,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
 					}
 				},
 				"asn1": {
@@ -3228,7 +3228,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"tweetnacl": "^0.14.3"
+						"tweetnacl": "0.14.5"
 					}
 				},
 				"block-stream": {
@@ -3236,7 +3236,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"inherits": "~2.0.0"
+						"inherits": "2.0.3"
 					}
 				},
 				"boom": {
@@ -3244,7 +3244,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"brace-expansion": {
@@ -3252,7 +3252,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "^0.4.1",
+						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3283,7 +3283,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"delayed-stream": "~1.0.0"
+						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
@@ -3307,7 +3307,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"boom": "2.x.x"
+						"boom": "2.10.1"
 					}
 				},
 				"dashdash": {
@@ -3316,7 +3316,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3359,7 +3359,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
+						"jsbn": "0.1.1"
 					}
 				},
 				"extend": {
@@ -3385,9 +3385,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
 					}
 				},
 				"fs.realpath": {
@@ -3400,10 +3400,10 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
 					}
 				},
 				"fstream-ignore": {
@@ -3412,9 +3412,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fstream": "^1.0.0",
-						"inherits": "2",
-						"minimatch": "^3.0.0"
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
 					}
 				},
 				"gauge": {
@@ -3423,14 +3423,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"getpass": {
@@ -3439,7 +3439,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^1.0.0"
+						"assert-plus": "1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3455,12 +3455,12 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"graceful-fs": {
@@ -3480,8 +3480,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
 					}
 				},
 				"has-unicode": {
@@ -3496,10 +3496,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
 					}
 				},
 				"hoek": {
@@ -3513,9 +3513,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
 					}
 				},
 				"inflight": {
@@ -3523,8 +3523,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -3543,7 +3543,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-typedarray": {
@@ -3569,7 +3569,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "~0.1.0"
+						"jsbn": "0.1.1"
 					}
 				},
 				"jsbn": {
@@ -3590,7 +3590,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsonify": "~0.0.0"
+						"jsonify": "0.0.0"
 					}
 				},
 				"json-stringify-safe": {
@@ -3635,7 +3635,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mime-db": "~1.27.0"
+						"mime-db": "1.27.0"
 					}
 				},
 				"minimatch": {
@@ -3643,7 +3643,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.7"
 					}
 				},
 				"minimist": {
@@ -3671,15 +3671,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"mkdirp": "^0.5.1",
-						"nopt": "^4.0.1",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"request": "^2.81.0",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^2.2.1",
-						"tar-pack": "^3.4.0"
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
 					}
 				},
 				"nopt": {
@@ -3688,8 +3688,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
 					}
 				},
 				"npmlog": {
@@ -3698,10 +3698,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3726,7 +3726,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -3747,8 +3747,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -3785,10 +3785,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "~0.4.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -3804,13 +3804,13 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"buffer-shims": "~1.0.0",
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~1.0.0",
-						"util-deprecate": "~1.0.1"
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"request": {
@@ -3819,28 +3819,28 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
 					}
 				},
 				"rimraf": {
@@ -3848,7 +3848,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -3880,7 +3880,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"hoek": "2.x.x"
+						"hoek": "2.16.3"
 					}
 				},
 				"sshpk": {
@@ -3889,15 +3889,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jodid25519": "^1.0.0",
-						"jsbn": "~0.1.0",
-						"tweetnacl": "~0.14.0"
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -3913,9 +3913,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -3923,7 +3923,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -3937,7 +3937,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -3951,9 +3951,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.2",
-						"inherits": "2"
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
 					}
 				},
 				"tar-pack": {
@@ -3962,14 +3962,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.2.0",
-						"fstream": "^1.0.10",
-						"fstream-ignore": "^1.0.5",
-						"once": "^1.3.3",
-						"readable-stream": "^2.1.4",
-						"rimraf": "^2.5.1",
-						"tar": "^2.2.1",
-						"uid-number": "^0.0.6"
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
 					}
 				},
 				"tough-cookie": {
@@ -3978,7 +3978,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"punycode": "^1.4.1"
+						"punycode": "1.4.1"
 					}
 				},
 				"tunnel-agent": {
@@ -3987,7 +3987,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.0.1"
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"tweetnacl": {
@@ -4028,7 +4028,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -4074,7 +4074,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"glob": {
@@ -4083,12 +4083,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -4097,8 +4097,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -4107,7 +4107,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"globals": {
@@ -4122,12 +4122,12 @@
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 			"dev": true,
 			"requires": {
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"graceful-fs": {
@@ -4148,8 +4148,8 @@
 			"integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
 			"dev": true,
 			"requires": {
-				"duplexer": "^0.1.1",
-				"pify": "^3.0.0"
+				"duplexer": "0.1.1",
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -4166,10 +4166,10 @@
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"dev": true,
 			"requires": {
-				"async": "^1.4.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.4.4",
-				"uglify-js": "^2.6"
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
 			},
 			"dependencies": {
 				"async": {
@@ -4184,7 +4184,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -4201,8 +4201,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -4211,7 +4211,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -4220,7 +4220,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-flag": {
@@ -4235,9 +4235,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4254,8 +4254,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -4264,7 +4264,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4273,7 +4273,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.5"
 							}
 						}
 					}
@@ -4284,7 +4284,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.5"
 					}
 				}
 			}
@@ -4294,11 +4294,11 @@
 			"resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
 			"integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
 			"requires": {
-				"invariant": "^2.2.1",
-				"loose-envify": "^1.2.0",
-				"resolve-pathname": "^2.2.0",
-				"value-equal": "^0.4.0",
-				"warning": "^3.0.0"
+				"invariant": "2.2.4",
+				"loose-envify": "1.3.1",
+				"resolve-pathname": "2.2.0",
+				"value-equal": "0.4.0",
+				"warning": "3.0.0"
 			},
 			"dependencies": {
 				"warning": {
@@ -4306,7 +4306,7 @@
 					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
 					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
 					"requires": {
-						"loose-envify": "^1.0.0"
+						"loose-envify": "1.3.1"
 					}
 				}
 			}
@@ -4322,8 +4322,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -4338,7 +4338,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.3"
 			}
 		},
 		"http-signature": {
@@ -4347,9 +4347,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.2"
 			}
 		},
 		"iconv-lite": {
@@ -4357,7 +4357,7 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
 			"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
 			"requires": {
-				"safer-buffer": "^2.1.0"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"ignore": {
@@ -4372,8 +4372,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
 			},
 			"dependencies": {
 				"pkg-dir": {
@@ -4382,7 +4382,7 @@
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.1.0"
+						"find-up": "2.1.0"
 					}
 				}
 			}
@@ -4399,8 +4399,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -4415,20 +4415,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.4",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4443,7 +4443,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -4452,9 +4452,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"strip-ansi": {
@@ -4463,7 +4463,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -4472,7 +4472,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -4482,7 +4482,7 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"invert-kv": {
@@ -4497,7 +4497,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-arrayish": {
@@ -4513,7 +4513,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.10.0"
 			}
 		},
 		"is-buffer": {
@@ -4528,7 +4528,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -4543,7 +4543,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "1.1.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -4552,7 +4552,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-date-object": {
@@ -4567,9 +4567,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4592,7 +4592,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -4613,7 +4613,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4634,7 +4634,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-module": {
@@ -4649,7 +4649,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-odd": {
@@ -4658,7 +4658,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0"
+				"is-number": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -4681,7 +4681,7 @@
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-path-inside": {
@@ -4690,7 +4690,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-object": {
@@ -4699,7 +4699,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4734,7 +4734,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.3"
 			}
 		},
 		"is-resolvable": {
@@ -4798,8 +4798,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.4"
 			}
 		},
 		"isstream": {
@@ -4814,18 +4814,18 @@
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"compare-versions": "^3.1.0",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.2.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"istanbul-lib-report": "^1.1.4",
-				"istanbul-lib-source-maps": "^1.2.4",
-				"istanbul-reports": "^1.3.0",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
+				"async": "2.6.1",
+				"compare-versions": "3.2.1",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.2.1",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.4",
+				"istanbul-lib-source-maps": "1.2.5",
+				"istanbul-reports": "1.3.0",
+				"js-yaml": "3.11.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -4840,7 +4840,7 @@
 			"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
 			"dev": true,
 			"requires": {
-				"append-transform": "^1.0.0"
+				"append-transform": "1.0.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -4849,13 +4849,13 @@
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.0",
-				"semver": "^5.3.0"
+				"babel-generator": "6.26.1",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"semver": "5.5.0"
 			},
 			"dependencies": {
 				"babylon": {
@@ -4872,10 +4872,10 @@
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -4890,7 +4890,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -4901,11 +4901,11 @@
 			"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.6"
 			},
 			"dependencies": {
 				"debug": {
@@ -4925,7 +4925,7 @@
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "4.0.11"
 			}
 		},
 		"jest": {
@@ -4934,8 +4934,8 @@
 			"integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
 			"dev": true,
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^23.1.0"
+				"import-local": "1.0.0",
+				"jest-cli": "23.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4950,7 +4950,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -4959,9 +4959,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"jest-cli": {
@@ -4970,41 +4970,41 @@
 					"integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.3.1",
-						"istanbul-lib-coverage": "^1.2.0",
-						"istanbul-lib-instrument": "^1.10.1",
-						"istanbul-lib-source-maps": "^1.2.4",
-						"jest-changed-files": "^23.0.1",
-						"jest-config": "^23.1.0",
-						"jest-environment-jsdom": "^23.1.0",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^23.1.0",
-						"jest-message-util": "^23.1.0",
-						"jest-regex-util": "^23.0.0",
-						"jest-resolve-dependencies": "^23.0.1",
-						"jest-runner": "^23.1.0",
-						"jest-runtime": "^23.1.0",
-						"jest-snapshot": "^23.0.1",
-						"jest-util": "^23.1.0",
-						"jest-validate": "^23.0.1",
-						"jest-watcher": "^23.1.0",
-						"jest-worker": "^23.0.1",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^11.0.0"
+						"ansi-escapes": "3.1.0",
+						"chalk": "2.4.1",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.3.1",
+						"istanbul-lib-coverage": "1.2.0",
+						"istanbul-lib-instrument": "1.10.1",
+						"istanbul-lib-source-maps": "1.2.5",
+						"jest-changed-files": "23.0.1",
+						"jest-config": "23.1.0",
+						"jest-environment-jsdom": "23.1.0",
+						"jest-get-type": "22.4.3",
+						"jest-haste-map": "23.1.0",
+						"jest-message-util": "23.1.0",
+						"jest-regex-util": "23.0.0",
+						"jest-resolve-dependencies": "23.0.1",
+						"jest-runner": "23.1.0",
+						"jest-runtime": "23.1.0",
+						"jest-snapshot": "23.0.1",
+						"jest-util": "23.1.0",
+						"jest-validate": "23.0.1",
+						"jest-watcher": "23.1.0",
+						"jest-worker": "23.0.1",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "11.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -5013,7 +5013,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"supports-color": {
@@ -5022,7 +5022,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5033,7 +5033,7 @@
 			"integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
 			"dev": true,
 			"requires": {
-				"throat": "^4.0.0"
+				"throat": "4.1.0"
 			}
 		},
 		"jest-config": {
@@ -5042,19 +5042,19 @@
 			"integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^23.0.1",
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^23.1.0",
-				"jest-environment-node": "^23.1.0",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.1.0",
-				"jest-regex-util": "^23.0.0",
-				"jest-resolve": "^23.1.0",
-				"jest-util": "^23.1.0",
-				"jest-validate": "^23.0.1",
-				"pretty-format": "^23.0.1"
+				"babel-core": "6.26.3",
+				"babel-jest": "23.0.1",
+				"chalk": "2.4.1",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "23.1.0",
+				"jest-environment-node": "23.1.0",
+				"jest-get-type": "22.4.3",
+				"jest-jasmine2": "23.1.0",
+				"jest-regex-util": "23.0.0",
+				"jest-resolve": "23.1.0",
+				"jest-util": "23.1.0",
+				"jest-validate": "23.0.1",
+				"pretty-format": "23.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5063,7 +5063,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5072,9 +5072,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5083,7 +5083,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5094,10 +5094,10 @@
 			"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.0.1"
+				"chalk": "2.4.1",
+				"diff": "3.5.0",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "23.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5106,7 +5106,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5115,9 +5115,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5126,7 +5126,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5137,7 +5137,7 @@
 			"integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			}
 		},
 		"jest-each": {
@@ -5146,8 +5146,8 @@
 			"integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"pretty-format": "^23.0.1"
+				"chalk": "2.4.1",
+				"pretty-format": "23.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5156,7 +5156,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5165,9 +5165,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5176,7 +5176,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5187,9 +5187,9 @@
 			"integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^23.1.0",
-				"jest-util": "^23.1.0",
-				"jsdom": "^11.5.1"
+				"jest-mock": "23.1.0",
+				"jest-util": "23.1.0",
+				"jsdom": "11.11.0"
 			}
 		},
 		"jest-environment-node": {
@@ -5198,8 +5198,8 @@
 			"integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^23.1.0",
-				"jest-util": "^23.1.0"
+				"jest-mock": "23.1.0",
+				"jest-util": "23.1.0"
 			}
 		},
 		"jest-get-type": {
@@ -5214,13 +5214,13 @@
 			"integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^23.0.1",
-				"jest-serializer": "^23.0.1",
-				"jest-worker": "^23.0.1",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "23.0.1",
+				"jest-serializer": "23.0.1",
+				"jest-worker": "23.0.1",
+				"micromatch": "2.3.11",
+				"sane": "2.5.2"
 			}
 		},
 		"jest-jasmine2": {
@@ -5229,17 +5229,17 @@
 			"integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^23.1.0",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^23.0.1",
-				"jest-each": "^23.1.0",
-				"jest-matcher-utils": "^23.0.1",
-				"jest-message-util": "^23.1.0",
-				"jest-snapshot": "^23.0.1",
-				"jest-util": "^23.1.0",
-				"pretty-format": "^23.0.1"
+				"chalk": "2.4.1",
+				"co": "4.6.0",
+				"expect": "23.1.0",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "23.0.1",
+				"jest-each": "23.1.0",
+				"jest-matcher-utils": "23.0.1",
+				"jest-message-util": "23.1.0",
+				"jest-snapshot": "23.0.1",
+				"jest-util": "23.1.0",
+				"pretty-format": "23.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5248,7 +5248,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5257,9 +5257,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5268,7 +5268,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5279,7 +5279,7 @@
 			"integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^23.0.1"
+				"pretty-format": "23.0.1"
 			}
 		},
 		"jest-matcher-utils": {
@@ -5288,9 +5288,9 @@
 			"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.0.1"
+				"chalk": "2.4.1",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "23.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5299,7 +5299,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5308,9 +5308,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5319,7 +5319,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5330,11 +5330,11 @@
 			"integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
-				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.0.0-beta.44",
+				"chalk": "2.4.1",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5343,7 +5343,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5352,9 +5352,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5363,7 +5363,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5386,9 +5386,9 @@
 			"integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "^1.11.2",
-				"chalk": "^2.0.1",
-				"realpath-native": "^1.0.0"
+				"browser-resolve": "1.11.2",
+				"chalk": "2.4.1",
+				"realpath-native": "1.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5397,7 +5397,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5406,9 +5406,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5417,7 +5417,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5428,8 +5428,8 @@
 			"integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^23.0.0",
-				"jest-snapshot": "^23.0.1"
+				"jest-regex-util": "23.0.0",
+				"jest-snapshot": "23.0.1"
 			}
 		},
 		"jest-runner": {
@@ -5438,19 +5438,19 @@
 			"integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
 			"dev": true,
 			"requires": {
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.1.0",
-				"jest-docblock": "^23.0.1",
-				"jest-haste-map": "^23.1.0",
-				"jest-jasmine2": "^23.1.0",
-				"jest-leak-detector": "^23.0.1",
-				"jest-message-util": "^23.1.0",
-				"jest-runtime": "^23.1.0",
-				"jest-util": "^23.1.0",
-				"jest-worker": "^23.0.1",
-				"source-map-support": "^0.5.6",
-				"throat": "^4.0.0"
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "23.1.0",
+				"jest-docblock": "23.0.1",
+				"jest-haste-map": "23.1.0",
+				"jest-jasmine2": "23.1.0",
+				"jest-leak-detector": "23.0.1",
+				"jest-message-util": "23.1.0",
+				"jest-runtime": "23.1.0",
+				"jest-util": "23.1.0",
+				"jest-worker": "23.0.1",
+				"source-map-support": "0.5.6",
+				"throat": "4.1.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -5465,8 +5465,8 @@
 					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
+						"buffer-from": "1.0.0",
+						"source-map": "0.6.1"
 					}
 				}
 			}
@@ -5477,27 +5477,27 @@
 			"integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-plugin-istanbul": "^4.1.6",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"exit": "^0.1.2",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.1.0",
-				"jest-haste-map": "^23.1.0",
-				"jest-message-util": "^23.1.0",
-				"jest-regex-util": "^23.0.0",
-				"jest-resolve": "^23.1.0",
-				"jest-snapshot": "^23.0.1",
-				"jest-util": "^23.1.0",
-				"jest-validate": "^23.0.1",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
+				"babel-core": "6.26.3",
+				"babel-plugin-istanbul": "4.1.6",
+				"chalk": "2.4.1",
+				"convert-source-map": "1.5.0",
+				"exit": "0.1.2",
+				"fast-json-stable-stringify": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-config": "23.1.0",
+				"jest-haste-map": "23.1.0",
+				"jest-message-util": "23.1.0",
+				"jest-regex-util": "23.0.0",
+				"jest-resolve": "23.1.0",
+				"jest-snapshot": "23.0.1",
+				"jest-util": "23.1.0",
+				"jest-validate": "23.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^11.0.0"
+				"write-file-atomic": "2.3.0",
+				"yargs": "11.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5506,7 +5506,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5515,9 +5515,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"strip-bom": {
@@ -5532,7 +5532,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5549,12 +5549,12 @@
 			"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^23.0.1",
-				"jest-matcher-utils": "^23.0.1",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^23.0.1"
+				"chalk": "2.4.1",
+				"jest-diff": "23.0.1",
+				"jest-matcher-utils": "23.0.1",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "23.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5563,7 +5563,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5572,9 +5572,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5583,7 +5583,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5594,14 +5594,14 @@
 			"integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^23.1.0",
-				"mkdirp": "^0.5.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.6.0"
+				"callsites": "2.0.0",
+				"chalk": "2.4.1",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "23.1.0",
+				"mkdirp": "0.5.1",
+				"slash": "1.0.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5610,7 +5610,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"callsites": {
@@ -5625,9 +5625,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"source-map": {
@@ -5642,7 +5642,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5653,10 +5653,10 @@
 			"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^23.0.1"
+				"chalk": "2.4.1",
+				"jest-get-type": "22.4.3",
+				"leven": "2.1.0",
+				"pretty-format": "23.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5665,7 +5665,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5674,9 +5674,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5685,7 +5685,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5696,9 +5696,9 @@
 			"integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"string-length": "^2.0.0"
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"string-length": "2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5707,7 +5707,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -5716,9 +5716,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -5727,7 +5727,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -5738,7 +5738,7 @@
 			"integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1"
+				"merge-stream": "1.0.1"
 			}
 		},
 		"js-tokens": {
@@ -5752,8 +5752,8 @@
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
 			}
 		},
 		"jsbn": {
@@ -5769,32 +5769,32 @@
 			"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"acorn": "^5.3.0",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": ">= 0.3.1 < 0.4.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.0",
-				"escodegen": "^1.9.0",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.2.0",
-				"nwsapi": "^2.0.0",
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.2",
+				"cssstyle": "0.3.1",
+				"data-urls": "1.0.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwsapi": "2.0.2",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.83.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.3",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^4.0.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.87.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.4.2",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
 			}
 		},
 		"jsesc": {
@@ -5851,7 +5851,7 @@
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3"
+				"array-includes": "3.0.3"
 			}
 		},
 		"kind-of": {
@@ -5860,7 +5860,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "^1.1.5"
+				"is-buffer": "1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -5876,7 +5876,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"left-pad": {
@@ -5897,8 +5897,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -5907,11 +5907,11 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
 			}
 		},
 		"locate-path": {
@@ -5920,8 +5920,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -5929,6 +5929,11 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
 			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
 			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -5947,7 +5952,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -5956,8 +5961,8 @@
 			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"magic-string": {
@@ -5966,7 +5971,7 @@
 			"integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
 			"dev": true,
 			"requires": {
-				"vlq": "^0.2.1"
+				"vlq": "0.2.3"
 			}
 		},
 		"makeerror": {
@@ -5975,7 +5980,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -5990,7 +5995,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"mem": {
@@ -5999,7 +6004,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"merge": {
@@ -6014,7 +6019,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.3"
 			}
 		},
 		"micromatch": {
@@ -6023,19 +6028,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.3"
 			}
 		},
 		"mime-db": {
@@ -6050,7 +6055,7 @@
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.33.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -6065,7 +6070,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.8"
 			}
 		},
 		"minimist": {
@@ -6080,8 +6085,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -6090,7 +6095,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -6129,18 +6134,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -6174,8 +6179,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
 			}
 		},
 		"node-int64": {
@@ -6190,10 +6195,10 @@
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"semver": "^5.4.1",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
 			}
 		},
 		"normalize-package-data": {
@@ -6202,10 +6207,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"normalize-path": {
@@ -6214,7 +6219,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.0.2"
 			}
 		},
 		"npm-run-path": {
@@ -6223,7 +6228,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"number-is-nan": {
@@ -6255,9 +6260,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6266,7 +6271,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -6283,7 +6288,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -6300,8 +6305,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.12.0"
 			}
 		},
 		"object.omit": {
@@ -6310,8 +6315,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -6320,7 +6325,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -6337,7 +6342,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -6346,7 +6351,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"optimist": {
@@ -6355,8 +6360,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -6373,12 +6378,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			}
 		},
 		"os-homedir": {
@@ -6393,9 +6398,9 @@
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -6410,9 +6415,9 @@
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.4",
-				"mkdirp": "^0.5.1",
-				"object-assign": "^4.1.0"
+				"graceful-fs": "4.1.11",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1"
 			}
 		},
 		"p-finally": {
@@ -6427,7 +6432,7 @@
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -6436,7 +6441,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.2.0"
 			}
 		},
 		"p-try": {
@@ -6451,10 +6456,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -6463,7 +6468,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.1"
 			}
 		},
 		"parse5": {
@@ -6529,9 +6534,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"performance-now": {
@@ -6558,7 +6563,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pkg-dir": {
@@ -6567,7 +6572,7 @@
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0"
+				"find-up": "1.1.2"
 			},
 			"dependencies": {
 				"find-up": {
@@ -6576,8 +6581,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -6586,7 +6591,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -6633,8 +6638,8 @@
 			"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6649,7 +6654,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -6677,7 +6682,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "~2.0.3"
+				"asap": "2.0.6"
 			}
 		},
 		"prop-types": {
@@ -6685,9 +6690,9 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
 			}
 		},
 		"pseudomap": {
@@ -6720,7 +6725,7 @@
 			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
 			"dev": true,
 			"requires": {
-				"performance-now": "^2.1.0"
+				"performance-now": "2.1.0"
 			}
 		},
 		"randomatic": {
@@ -6729,8 +6734,8 @@
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6739,7 +6744,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6748,7 +6753,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.5"
 							}
 						}
 					}
@@ -6759,7 +6764,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.5"
 					}
 				}
 			}
@@ -6770,10 +6775,10 @@
 			"integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-addons-test-utils": {
@@ -6788,10 +6793,10 @@
 			"integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"read-pkg": {
@@ -6800,9 +6805,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
 			}
 		},
 		"read-pkg-up": {
@@ -6811,8 +6816,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -6821,8 +6826,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -6831,7 +6836,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -6842,13 +6847,13 @@
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~1.0.6",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.0.3",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -6858,10 +6863,10 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.3",
+				"set-immediate-shim": "1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -6870,7 +6875,7 @@
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"regenerate": {
@@ -6891,9 +6896,9 @@
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
+				"babel-runtime": "6.25.0",
+				"babel-types": "6.25.0",
+				"private": "0.1.7"
 			}
 		},
 		"regex-cache": {
@@ -6902,8 +6907,8 @@
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3",
-				"is-primitive": "^2.0.0"
+				"is-equal-shallow": "0.1.3",
+				"is-primitive": "2.0.0"
 			}
 		},
 		"regex-not": {
@@ -6912,8 +6917,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexpp": {
@@ -6928,9 +6933,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.3.2",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"regjsgen": {
@@ -6945,7 +6950,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -6980,7 +6985,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"request": {
@@ -6989,26 +6994,26 @@
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.7.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.1",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -7023,7 +7028,7 @@
 					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 					"dev": true,
 					"requires": {
-						"punycode": "^1.4.1"
+						"punycode": "1.4.1"
 					}
 				}
 			}
@@ -7034,7 +7039,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "4.17.4"
 			}
 		},
 		"request-promise-native": {
@@ -7044,8 +7049,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.4.2"
 			}
 		},
 		"require-directory": {
@@ -7066,8 +7071,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			}
 		},
 		"resolve": {
@@ -7076,7 +7081,7 @@
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -7085,7 +7090,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -7119,8 +7124,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -7136,7 +7141,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.1"
+				"align-text": "0.1.4"
 			}
 		},
 		"rimraf": {
@@ -7145,7 +7150,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"rollup": {
@@ -7155,7 +7160,7 @@
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "10.3.1"
 			}
 		},
 		"rollup-plugin-babel": {
@@ -7164,7 +7169,7 @@
 			"integrity": "sha512-TGhQbliTZnRoUhd2214K3r4KJUBu9J1DPzcrAnkluVXOVrveU9OvAaYQ16KyOmujAoq+LMC1+x6YF2xBrU7t+g==",
 			"dev": true,
 			"requires": {
-				"rollup-pluginutils": "^1.5.0"
+				"rollup-pluginutils": "1.5.2"
 			}
 		},
 		"rollup-plugin-commonjs": {
@@ -7173,10 +7178,10 @@
 			"integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
 			"dev": true,
 			"requires": {
-				"estree-walker": "^0.5.1",
-				"magic-string": "^0.22.4",
-				"resolve": "^1.5.0",
-				"rollup-pluginutils": "^2.0.1"
+				"estree-walker": "0.5.2",
+				"magic-string": "0.22.4",
+				"resolve": "1.7.1",
+				"rollup-pluginutils": "2.3.0"
 			},
 			"dependencies": {
 				"estree-walker": {
@@ -7191,8 +7196,8 @@
 					"integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
 					"dev": true,
 					"requires": {
-						"estree-walker": "^0.5.2",
-						"micromatch": "^2.3.11"
+						"estree-walker": "0.5.2",
+						"micromatch": "2.3.11"
 					}
 				}
 			}
@@ -7203,9 +7208,9 @@
 			"integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^2.0.0",
-				"is-module": "^1.0.0",
-				"resolve": "^1.1.6"
+				"builtin-modules": "2.0.0",
+				"is-module": "1.0.0",
+				"resolve": "1.7.1"
 			},
 			"dependencies": {
 				"builtin-modules": {
@@ -7222,9 +7227,9 @@
 			"integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
 			"dev": true,
 			"requires": {
-				"magic-string": "^0.22.4",
-				"minimatch": "^3.0.2",
-				"rollup-pluginutils": "^2.0.1"
+				"magic-string": "0.22.4",
+				"minimatch": "3.0.4",
+				"rollup-pluginutils": "2.0.1"
 			},
 			"dependencies": {
 				"estree-walker": {
@@ -7239,8 +7244,8 @@
 					"integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
 					"dev": true,
 					"requires": {
-						"estree-walker": "^0.3.0",
-						"micromatch": "^2.3.11"
+						"estree-walker": "0.3.1",
+						"micromatch": "2.3.11"
 					}
 				}
 			}
@@ -7251,7 +7256,7 @@
 			"integrity": "sha512-dehLu9eRRoV4l09aC+ySntRw1OAfoyKdbk8Nelblj03tHoynkSybqyEpgavemi1LBOH6S1vzI58/mpxkZIe1iQ==",
 			"dev": true,
 			"requires": {
-				"uglify-es": "^3.3.7"
+				"uglify-es": "3.3.8"
 			},
 			"dependencies": {
 				"commander": {
@@ -7272,8 +7277,8 @@
 					"integrity": "sha512-j8li0jWcAN6yBuAVYFZEFyYINZAm4WEdMwkA6qXFi4TLrze3Mp0Le7QjW6LR9HQjQJ2zRa9VgnFLs3PatijWOw==",
 					"dev": true,
 					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
+						"commander": "2.13.0",
+						"source-map": "0.6.1"
 					}
 				}
 			}
@@ -7284,8 +7289,8 @@
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
 			"dev": true,
 			"requires": {
-				"estree-walker": "^0.2.1",
-				"minimatch": "^3.0.2"
+				"estree-walker": "0.2.1",
+				"minimatch": "3.0.4"
 			}
 		},
 		"rsvp": {
@@ -7300,7 +7305,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -7315,7 +7320,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"safe-buffer": {
@@ -7330,7 +7335,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -7344,15 +7349,15 @@
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"capture-exit": "^1.2.0",
-				"exec-sh": "^0.2.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.3",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"anymatch": "2.0.0",
+				"capture-exit": "1.2.0",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.4",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
 			},
 			"dependencies": {
 				"anymatch": {
@@ -7361,8 +7366,8 @@
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"dev": true,
 					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
+						"micromatch": "3.1.10",
+						"normalize-path": "2.1.1"
 					}
 				},
 				"arr-diff": {
@@ -7383,16 +7388,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7401,7 +7406,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7412,13 +7417,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.8",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -7427,7 +7432,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -7436,7 +7441,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -7445,7 +7450,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -7454,7 +7459,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.5"
 									}
 								}
 							}
@@ -7465,7 +7470,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -7474,7 +7479,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.5"
 									}
 								}
 							}
@@ -7485,9 +7490,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -7504,14 +7509,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -7520,7 +7525,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -7529,7 +7534,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7540,10 +7545,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7552,7 +7557,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7564,8 +7569,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"nan": "^2.9.2",
-						"node-pre-gyp": "^0.10.0"
+						"nan": "2.10.0",
+						"node-pre-gyp": "0.10.0"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -7591,8 +7596,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
+								"delegates": "1.0.0",
+								"readable-stream": "2.3.6"
 							}
 						},
 						"balanced-match": {
@@ -7605,7 +7610,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"balanced-match": "^1.0.0",
+								"balanced-match": "1.0.0",
 								"concat-map": "0.0.1"
 							}
 						},
@@ -7669,7 +7674,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"minipass": "^2.2.1"
+								"minipass": "2.2.4"
 							}
 						},
 						"fs.realpath": {
@@ -7684,14 +7689,14 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
+								"aproba": "1.2.0",
+								"console-control-strings": "1.1.0",
+								"has-unicode": "2.0.1",
+								"object-assign": "4.1.1",
+								"signal-exit": "3.0.2",
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wide-align": "1.1.2"
 							}
 						},
 						"glob": {
@@ -7700,12 +7705,12 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
+								"fs.realpath": "1.0.0",
+								"inflight": "1.0.6",
+								"inherits": "2.0.3",
+								"minimatch": "3.0.4",
+								"once": "1.4.0",
+								"path-is-absolute": "1.0.1"
 							}
 						},
 						"has-unicode": {
@@ -7720,7 +7725,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"safer-buffer": "^2.1.0"
+								"safer-buffer": "2.1.2"
 							}
 						},
 						"ignore-walk": {
@@ -7729,7 +7734,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"minimatch": "^3.0.4"
+								"minimatch": "3.0.4"
 							}
 						},
 						"inflight": {
@@ -7738,8 +7743,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
+								"once": "1.4.0",
+								"wrappy": "1.0.2"
 							}
 						},
 						"inherits": {
@@ -7758,7 +7763,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "^1.0.0"
+								"number-is-nan": "1.0.1"
 							}
 						},
 						"isarray": {
@@ -7772,7 +7777,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"brace-expansion": "^1.1.7"
+								"brace-expansion": "1.1.11"
 							}
 						},
 						"minimist": {
@@ -7785,8 +7790,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "^5.1.1",
-								"yallist": "^3.0.0"
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
 							}
 						},
 						"minizlib": {
@@ -7795,7 +7800,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"minipass": "^2.2.1"
+								"minipass": "2.2.4"
 							}
 						},
 						"mkdirp": {
@@ -7818,9 +7823,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"debug": "^2.1.2",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
+								"debug": "2.6.9",
+								"iconv-lite": "0.4.21",
+								"sax": "1.2.4"
 							}
 						},
 						"node-pre-gyp": {
@@ -7829,16 +7834,16 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.0",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.1.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4"
+								"detect-libc": "1.0.3",
+								"mkdirp": "0.5.1",
+								"needle": "2.2.0",
+								"nopt": "4.0.1",
+								"npm-packlist": "1.1.10",
+								"npmlog": "4.1.2",
+								"rc": "1.2.7",
+								"rimraf": "2.6.2",
+								"semver": "5.5.0",
+								"tar": "4.4.1"
 							}
 						},
 						"nopt": {
@@ -7847,8 +7852,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
+								"abbrev": "1.1.1",
+								"osenv": "0.1.5"
 							}
 						},
 						"npm-bundled": {
@@ -7863,8 +7868,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
+								"ignore-walk": "3.0.1",
+								"npm-bundled": "1.0.3"
 							}
 						},
 						"npmlog": {
@@ -7873,10 +7878,10 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
+								"are-we-there-yet": "1.1.4",
+								"console-control-strings": "1.1.0",
+								"gauge": "2.7.4",
+								"set-blocking": "2.0.0"
 							}
 						},
 						"number-is-nan": {
@@ -7895,7 +7900,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"wrappy": "1"
+								"wrappy": "1.0.2"
 							}
 						},
 						"os-homedir": {
@@ -7916,8 +7921,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
+								"os-homedir": "1.0.2",
+								"os-tmpdir": "1.0.2"
 							}
 						},
 						"path-is-absolute": {
@@ -7938,10 +7943,10 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"deep-extend": "^0.5.1",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
+								"deep-extend": "0.5.1",
+								"ini": "1.3.5",
+								"minimist": "1.2.0",
+								"strip-json-comments": "2.0.1"
 							},
 							"dependencies": {
 								"minimist": {
@@ -7958,13 +7963,13 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.3",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.1",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"rimraf": {
@@ -7973,7 +7978,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"glob": "^7.0.5"
+								"glob": "7.1.2"
 							}
 						},
 						"safe-buffer": {
@@ -8016,9 +8021,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						},
 						"string_decoder": {
@@ -8027,7 +8032,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.1"
 							}
 						},
 						"strip-ansi": {
@@ -8035,7 +8040,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^2.0.0"
+								"ansi-regex": "2.1.1"
 							}
 						},
 						"strip-json-comments": {
@@ -8050,13 +8055,13 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"chownr": "^1.0.1",
-								"fs-minipass": "^1.2.5",
-								"minipass": "^2.2.4",
-								"minizlib": "^1.1.0",
-								"mkdirp": "^0.5.0",
-								"safe-buffer": "^5.1.1",
-								"yallist": "^3.0.2"
+								"chownr": "1.0.1",
+								"fs-minipass": "1.2.5",
+								"minipass": "2.2.4",
+								"minizlib": "1.1.0",
+								"mkdirp": "0.5.1",
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
 							}
 						},
 						"util-deprecate": {
@@ -8071,7 +8076,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"string-width": "^1.0.2"
+								"string-width": "1.0.2"
 							}
 						},
 						"wrappy": {
@@ -8092,7 +8097,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -8101,7 +8106,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -8110,9 +8115,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -8121,7 +8126,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -8130,7 +8135,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.5"
 							}
 						}
 					}
@@ -8153,19 +8158,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"minimist": {
@@ -8214,10 +8219,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -8226,7 +8231,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -8242,7 +8247,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -8275,7 +8280,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0"
+				"is-fullwidth-code-point": "2.0.0"
 			}
 		},
 		"snapdragon": {
@@ -8284,14 +8289,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.8",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.6",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8300,7 +8305,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -8309,7 +8314,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -8320,9 +8325,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8331,7 +8336,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -8340,7 +8345,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -8349,7 +8354,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -8358,9 +8363,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -8383,7 +8388,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			}
 		},
 		"source-map": {
@@ -8398,11 +8403,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.1",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -8411,7 +8416,7 @@
 			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.5.6"
+				"source-map": "0.5.6"
 			}
 		},
 		"source-map-url": {
@@ -8426,8 +8431,8 @@
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -8442,8 +8447,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -8458,7 +8463,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -8473,15 +8478,15 @@
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"stack-utils": {
@@ -8496,8 +8501,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8506,7 +8511,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -8523,8 +8528,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8539,7 +8544,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -8550,8 +8555,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8566,7 +8571,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -8577,7 +8582,7 @@
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"strip-ansi": {
@@ -8586,7 +8591,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-bom": {
@@ -8595,7 +8600,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "^0.2.0"
+				"is-utf8": "0.2.1"
 			}
 		},
 		"strip-eof": {
@@ -8628,12 +8633,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-keywords": "^2.1.0",
-				"chalk": "^2.1.0",
-				"lodash": "^4.17.4",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.4.1",
+				"lodash": "4.17.4",
 				"slice-ansi": "1.0.0",
-				"string-width": "^2.1.1"
+				"string-width": "2.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8642,7 +8647,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"chalk": {
@@ -8651,9 +8656,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"supports-color": {
@@ -8662,7 +8667,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8673,11 +8678,11 @@
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^3.1.8",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
-				"require-main-filename": "^1.0.1"
+				"arrify": "1.0.1",
+				"micromatch": "3.1.10",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -8698,16 +8703,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -8716,7 +8721,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -8727,13 +8732,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.8",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -8742,7 +8747,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -8751,7 +8756,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -8760,7 +8765,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -8769,7 +8774,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.5"
 									}
 								}
 							}
@@ -8780,7 +8785,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -8789,7 +8794,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.5"
 									}
 								}
 							}
@@ -8800,9 +8805,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -8819,14 +8824,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -8835,7 +8840,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -8844,7 +8849,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -8855,10 +8860,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -8867,7 +8872,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -8878,7 +8883,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -8887,7 +8892,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -8896,9 +8901,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -8907,7 +8912,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -8916,7 +8921,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.5"
 							}
 						}
 					}
@@ -8939,19 +8944,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				}
 			}
@@ -8980,7 +8985,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"tmpl": {
@@ -9001,7 +9006,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"to-regex": {
@@ -9010,10 +9015,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -9022,8 +9027,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -9032,7 +9037,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				}
 			}
@@ -9043,8 +9048,8 @@
 			"integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
+				"psl": "1.1.27",
+				"punycode": "1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -9061,7 +9066,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			}
 		},
 		"trim-right": {
@@ -9076,7 +9081,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"tweetnacl": {
@@ -9092,7 +9097,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"typedarray": {
@@ -9113,9 +9118,9 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "~0.5.1",
-				"uglify-to-browserify": "~1.0.0",
-				"yargs": "~3.10.0"
+				"source-map": "0.5.6",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
 			},
 			"dependencies": {
 				"yargs": {
@@ -9125,9 +9130,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -9146,10 +9151,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -9158,7 +9163,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -9167,10 +9172,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -9181,8 +9186,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -9191,9 +9196,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -9233,7 +9238,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.2"
+				"kind-of": "6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -9262,8 +9267,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"uuid": {
@@ -9278,7 +9283,7 @@
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
 			"dev": true,
 			"requires": {
-				"user-home": "^1.1.1"
+				"user-home": "1.1.1"
 			}
 		},
 		"validate-npm-package-license": {
@@ -9287,8 +9292,8 @@
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"value-equal": {
@@ -9302,9 +9307,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vlq": {
@@ -9319,7 +9324,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.2"
 			}
 		},
 		"walker": {
@@ -9328,7 +9333,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"warning": {
@@ -9336,7 +9341,7 @@
 			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
 			"integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"watch": {
@@ -9345,8 +9350,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -9397,9 +9402,9 @@
 			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"which": {
@@ -9408,7 +9413,7 @@
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -9436,8 +9441,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -9446,7 +9451,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -9455,9 +9460,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -9474,7 +9479,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -9483,9 +9488,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ws": {
@@ -9494,8 +9499,8 @@
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0",
-				"safe-buffer": "~5.1.0"
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"xml-name-validator": {
@@ -9522,18 +9527,18 @@
 			"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 			"dev": true,
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^9.0.2"
+				"cliui": "4.1.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "9.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -9548,9 +9553,9 @@
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -9559,7 +9564,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -9570,7 +9575,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -41,6 +41,7 @@
     "history": "^4.7.2",
     "hoist-non-react-statics": "^2.5.0",
     "invariant": "^2.2.4",
+    "lodash.isequal": "^4.5.0",
     "loose-envify": "^1.3.1",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.6.1",

--- a/website/modules/animated/createAnimatedComponent.js
+++ b/website/modules/animated/createAnimatedComponent.js
@@ -35,7 +35,7 @@ function createAnimatedComponent(Component: any): any {
       }
     }
 
-    componentWillMount() {
+    componentDidMount() {
       this.attachProps(this.props);
     }
 
@@ -72,8 +72,8 @@ function createAnimatedComponent(Component: any): any {
       oldPropsAnimated && oldPropsAnimated.__detach();
     }
 
-    componentWillReceiveProps(nextProps) {
-      this.attachProps(nextProps);
+    componentDidUpdate() {
+      this.attachProps(this.props);
     }
 
     render() {

--- a/website/modules/components/Bundle.js
+++ b/website/modules/components/Bundle.js
@@ -5,13 +5,13 @@ class Bundle extends Component {
     mod: null
   };
 
-  componentWillMount() {
+  componentDidMount() {
     this.load(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.load !== this.props.load) {
-      this.load(nextProps);
+  componentDidUpdate(prevProps) {
+    if (prevProps.load !== this.props.load) {
+      this.load(this.props);
     }
   }
 

--- a/website/modules/components/EnvironmentSmall.js
+++ b/website/modules/components/EnvironmentSmall.js
@@ -46,16 +46,16 @@ class EnvironmentSmall extends Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const { anim } = this.state;
 
     // only animate if we're going from here to direct child.
     // child to child we'll ignore
     const goingToChild =
-      nextProps.match.isExact === false && this.props.match.isExact === true;
+      this.props.match.isExact === false && prevProps.match.isExact === true;
 
     const comingFromChild =
-      nextProps.match.isExact === true && this.props.match.isExact === false;
+      this.props.match.isExact === true && prevProps.match.isExact === false;
 
     if (goingToChild || comingFromChild) {
       this.setState(
@@ -102,7 +102,11 @@ class EnvironmentSmall extends Component {
               <Switch location={location}>
                 <Route
                   path={paths.api(match)}
-                  render={({ match: { params: { mod } } }) => (
+                  render={({
+                    match: {
+                      params: { mod }
+                    }
+                  }) => (
                     <Header
                       url={match.url}
                       fontFamily="Menlo, monospace"
@@ -114,7 +118,11 @@ class EnvironmentSmall extends Component {
                 />
                 <Route
                   path={paths.example(match)}
-                  render={({ match: { params: { example } } }) => (
+                  render={({
+                    match: {
+                      params: { example }
+                    }
+                  }) => (
                     <Header url={match.url}>
                       {getExampleTitle(data, example)}
                     </Header>
@@ -122,7 +130,11 @@ class EnvironmentSmall extends Component {
                 />
                 <Route
                   path={paths.guide(match)}
-                  render={({ match: { params: { mod } } }) => (
+                  render={({
+                    match: {
+                      params: { mod }
+                    }
+                  }) => (
                     <Header url={match.url}>{getGuideTitle(data, mod)}</Header>
                   )}
                 />
@@ -264,13 +276,13 @@ class AnimatedChild extends Component {
     previousChildren: null
   };
 
-  componentWillReceiveProps(nextProps) {
-    const navigatingToParent = nextProps.atParent && !this.props.atParent;
-    const animationEnded = this.props.animating && !nextProps.animating;
+  componentDidUpdate(prevProps) {
+    const navigatingToParent = this.props.atParent && !prevProps.atParent;
+    const animationEnded = prevProps.animating && !this.props.animating;
 
     if (navigatingToParent) {
       this.setState({
-        previousChildren: this.props.children
+        previousChildren: prevProps.children
       });
     } else if (animationEnded) {
       this.setState({
@@ -328,13 +340,13 @@ class AnimatedChildHeader extends Component {
     previousChildren: null
   };
 
-  componentWillReceiveProps(nextProps) {
-    const navigatingToParent = nextProps.atParent && !this.props.atParent;
-    const animationEnded = this.props.animating && !nextProps.animating;
+  componentDidUpdate(prevProps) {
+    const navigatingToParent = this.props.atParent && !prevProps.atParent;
+    const animationEnded = prevProps.animating && !this.props.animating;
 
     if (navigatingToParent) {
       this.setState({
-        previousChildren: this.props.children
+        previousChildren: prevProps.children
       });
     } else if (animationEnded) {
       this.setState({

--- a/website/modules/components/PanGesture.js
+++ b/website/modules/components/PanGesture.js
@@ -46,9 +46,9 @@ class PanGesture extends Component {
     }
   }
 
-  componentWillReceiveProps(next) {
-    if (this.props.when !== next.when) {
-      if (next.when) {
+  componentDidUpdate(prevProps) {
+    if (this.props.when !== prevProps.when) {
+      if (this.props.when) {
         this.listen();
       } else {
         this.unlisten();


### PR DESCRIPTION
Removed all instances of `componentWillMount` and `componentWillReceiveProps`

For the most part, cWM was changed to cDM, except in cases where a parent's function needed to be run before a child's, so those were moved into the constructor. (see `Router.js` as an example).

cWRP was replaced with componentDidUpdate. In one case where infinite loops could happen, I added an equality check to stop that. (see `Route.js`).

Updated all documentation and examples to remove the old lifecycles and use their supported counterparts.

It appears that my IDE picked up on the ESLint configs that were installed and make some changes as well, such as adding `;` and changing single to double quotes `"`. I'm sorry about that, and I'm not too happy about it. :(

